### PR TITLE
Adapt spec file to work with old SLE12 versions

### DIFF
--- a/python-shaptools.spec
+++ b/python-shaptools.spec
@@ -14,8 +14,6 @@
 
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 
-
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-shaptools
 Version:        0.1.0
 Release:        0
@@ -24,36 +22,62 @@ Summary:        Python tools to interact with SAP HANA utilities
 Url:            https://github.com/SUSE/shaptools
 Group:          Development/Languages/Python
 Source:         shaptools-%{version}.tar.gz
-BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module devel}
-BuildRequires:  %{python_module setuptools}
-BuildRequires:  unzip
+BuildRequires:  python-devel python3-devel
+BuildRequires:  python-setuptools python3-setuptools
 BuildRequires:  fdupes
 BuildArch:      noarch
 
-%python_subpackages
-
 %description
 API to expose SAP HANA functionalities
+
+%package -n python2-shaptools
+Summary:        Python tools to interact with SAP HANA utilities (python2)
+%{?python_provide:%python_provide python2-shaptools}
+
+%description -n python2-shaptools
+API to expose SAP HANA functionalities (python2)
+
+%package -n python3-shaptools
+Summary:        Python tools to interact with SAP HANA utilities (python3)
+%{?python_provide:%python_provide python3-shaptools}
+
+%description -n python3-shaptools
+API to expose SAP HANA functionalities (python3)
 
 %prep
 %setup -q -n shaptools-%{version}
 
 %build
-%python_build
+python2 setup.py build --build-lib=py2/build/lib
+python3 setup.py build --build-lib=py3/build/lib
 
 %install
-%python_install
-%python_expand %fdupes %{buildroot}%{$python_sitelib}
+mv py2/build .
+python2 setup.py install -O1 --skip-build --force --root %{buildroot} --prefix=%{_prefix}
+%fdupes %{buildroot}%python_sitelib
+rm -rf build
+mv py3/build .
+python3 setup.py install -O1 --skip-build --force --root %{buildroot} --prefix=%{_prefix}
+%fdupes %{buildroot}%python3_sitelib
 
-%files %{python_files}
+%files -n python2-shaptools
 %doc CHANGELOG.md README.md
-# %license macro is not availabe on older releases
+# %license macro is not available on older releases
 %if 0%{?sle_version} <= 120300
 %doc LICENSE
 %else
 %license LICENSE
 %endif
 %{python_sitelib}/*
+
+%files -n python3-shaptools
+%doc CHANGELOG.md README.md
+# %license macro is not available on older releases
+%if 0%{?sle_version} <= 120300
+%doc LICENSE
+%else
+%license LICENSE
+%endif
+%{python3_sitelib}/*
 
 %changelog


### PR DESCRIPTION
Spec file updated to work with sles version without python rpm macros.

Could you have a look to see if it can be improved?

**Now on python2-shaptools and python3-shaptools packages will be created and not python-shaptools**