### PR TITLE
Functionality to manage HANA ini paramaters

### DIFF
--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -510,7 +510,7 @@ class HanaInstance:
 
         key_name or user_name/user_password parameters must be used
         Args:
-            ini_parameter_values(list): List containing HANA parameter details
+            ini_parameter_values (list): List containing HANA parameter details
             where each entry is a dictionary like below:
             {'section_name':'name', 'parameter_name':'param_name', 'parameter_value':'value'}
                 section_name (str): Section name of parameter in ini file

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -377,13 +377,13 @@ class HanaInstance:
         Args:
             key_name (str, optional): Keystore to connect to sap hana db
             user_name (str, optional): User to connect to sap hana db
-            user_password (str, optiona): Password to connecto to sap hana db
+            user_password (str, optional): Password to connect to sap hana db
         """
         if kwargs.get('key_name', None):
-            cmd = 'hdbsql -U {}'.format(kwargs['key_name'])
+            cmd = 'hdbsql -i {} -U {}'.format(self.inst, kwargs['key_name'])
         elif kwargs.get('user_name', None) and kwargs.get('user_password', None):
-            cmd = 'hdbsql -u {} -p {}'.format(
-                kwargs['user_name'], kwargs['user_password'])
+            cmd = 'hdbsql -i {} -u {} -p {}'.format(
+                self.inst, kwargs['user_name'], kwargs['user_password'])
         else:
             raise ValueError(
                 'key_name or user_name/user_password parameters must be used')

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -448,3 +448,135 @@ class HanaInstance:
         # (see SAPHana RA)
         status["status"] = SR_STATUS.get(result.returncode, SR_STATUS[12])
         return status
+
+    def _manage_ini_file(
+            self, parameter_str, database, file_name, layer,
+            **kwargs):
+        """
+        Construct command with HANA SQL to update configuration parameters in ini file
+
+        key_name or user_name/user_password parameters must be used
+        Args:
+            parameter_str (list): List containing HANA parameter details in a dict format
+            database (str): Database name
+            file_name (str): INI configuration file name
+            layer (str): Target layer for the configuration change 'SYSTEM', 'HOST' or 'DATABASE'
+            layer_name (str, optional): Target either a tenant name or a target host name
+            reconfig (bool, optional): If apply changes to running HANA instance
+            set_value (bool, optional): Choose SET or UNSET operation to update parameters
+            key_name (str, optional): Keystore to connect to sap hana db
+            user_name (str, optional): User to connect to sap hana db
+            user_password (str, optional): Password to connect to sap hana db
+        """
+        layer_name = kwargs.get('layer_name', None)
+        reconfig = kwargs.get('reconfig', False)
+        set_value = kwargs.get('set_value', True)
+        key_name = kwargs.get('key_name', None)
+        user_name = kwargs.get('user_name', None)
+        user_password = kwargs.get('user_password', None)
+
+        hdbsql_cmd = self._hdbsql_connect(
+            key_name=key_name, user_name=user_name, user_password=user_password)
+
+        if layer in ('HOST', 'DATABASE') and layer_name is not None:
+            layer_name_str = ', \'{}\''.format(layer_name)
+        else:
+            layer_name_str = ''
+
+        set_str = 'SET' if set_value else 'UNSET'
+        reconfig_option = ' WITH RECONFIGURE' if reconfig else ''
+
+        cmd = ('{hdbsql_cmd} -d {db} '
+               '\\"ALTER SYSTEM ALTER CONFIGURATION(\'{file_name}\', \'{layer}\'{layer_name}) '
+               '{set_str}{parameter_str}{reconfig};\\"'.format(
+                   hdbsql_cmd=hdbsql_cmd, db=database, file_name=file_name, layer=layer,
+                   layer_name=layer_name_str, set_str=set_str, parameter_str=parameter_str,
+                   reconfig=reconfig_option))
+
+        # TODO: return the HANA SQL Statement error if sql fails
+        self._run_hana_command(cmd)
+
+    def set_ini_parameter(
+            self, ini_parameter_values, database, file_name, layer,
+            **kwargs):
+        """
+        Set HANA configuration parameters in ini file
+
+        SQL syntax:
+        ALTER SYSTEM ALTER CONFIGURATION (<filename>, <layer>[, <layer_name>])
+        SET (<section_name_1>,<parameter_name_1>) = <parameter_value_1>,
+            (<section_name_2>,<parameter_name_2>) = <parameter_value_2>
+        WITH RECONFIGURE
+
+        key_name or user_name/user_password parameters must be used
+        Args:
+            ini_parameter_values(list): List containing HANA parameter details
+            where each entry is a dictionary like below:
+            {'section_name':'name', 'parameter_name':'param_name', 'parameter_value':'value'}
+                section_name (str): Section name of parameter in ini file
+                parameter_name (str): Name of the parameter to be modified
+                parameter_value (str): The value of the parameter to be set
+            database (str): Database name
+            file_name (str): INI configuration file name
+            layer (str): Target layer for the configuration change 'SYSTEM', 'HOST' or 'DATABASE'
+            layer_name (str, optional): Target either a tenant name or a target host name
+            reconfig (bool, optional): If apply changes to running HANA instance
+            key_name (str, optional): Keystore to connect to sap hana db
+            user_name (str, optional): User to connect to sap hana db
+            user_password (str, optional): Password to connect to sap hana db
+        """
+
+        parameter_str = ', '.join("(\'{}\',\'{}\')=\'{}\'".format(
+            params['section_name'], params['parameter_name'],
+            params['parameter_value']) for params in ini_parameter_values)
+
+        layer_name = kwargs.get('layer_name', None)
+        reconfig = kwargs.get('reconfig', False)
+        key_name = kwargs.get('key_name', None)
+        user_name = kwargs.get('user_name', None)
+        user_password = kwargs.get('user_password', None)
+
+        self._manage_ini_file(parameter_str=parameter_str, database=database,
+                              file_name=file_name, layer=layer, layer_name=layer_name,
+                              set_value=True, reconfig=reconfig, key_name=key_name,
+                              user_name=user_name, user_password=user_password)
+
+    def unset_ini_parameter(
+            self, ini_parameter_names, database, file_name, layer,
+            **kwargs):
+        """
+        Unset HANA configuration parameters in ini file
+
+        SQL syntax:
+        ALTER SYSTEM ALTER CONFIGURATION (<filename>, <layer>[, <layer_name>])
+        UNSET (<section_name>,<parameter_name>);
+
+        key_name or user_name/user_password parameters must be used
+        Args:
+            ini_parameter_names (list): List containing HANA parameter details
+            where each entry is a dictionary like below:
+            {'section_name':'name', 'parameter_name':'param_name'}
+                section_name (str): Section name of parameter in ini file
+                parameter_name (str): Name of the parameter to be modified
+            database (str): Database name
+            file_name (str): INI configuration file name
+            layer (str): Target layer for the configuration change 'SYSTEM', 'HOST' or 'DATABASE'
+            layer_name (str, optional): Target either a tenant name or a target host name
+            reconfig (bool, optional): If apply changes to running HANA instance
+            key_name (str, optional): Keystore to connect to sap hana db
+            user_name (str, optional): User to connect to sap hana db
+            user_password (str, optional): Password to connect to sap hana db
+        """
+        parameter_str = ', '.join("(\'{}\',\'{}\')".format(
+            params['section_name'], params['parameter_name']) for params in ini_parameter_names)
+
+        layer_name = kwargs.get('layer_name', None)
+        reconfig = kwargs.get('reconfig', False)
+        key_name = kwargs.get('key_name', None)
+        user_name = kwargs.get('user_name', None)
+        user_password = kwargs.get('user_password', None)
+
+        self._manage_ini_file(parameter_str=parameter_str, database=database,
+                              file_name=file_name, layer=layer, layer_name=layer_name,
+                              set_value=False, reconfig=reconfig, key_name=key_name,
+                              user_name=user_name, user_password=user_password)

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -508,6 +508,129 @@ class TestHana(unittest.TestCase):
                 'HDBSettings.sh systemReplicationStatus.py', exception=False)
             self.assertEqual(status, {"status": expect})
     
+    def test_set_ini_parameter(self):
+        mock_command = mock.Mock()
+        self._hana._run_hana_command = mock_command
+        mock_hdbsql = mock.Mock(return_value='hdbsql')
+        self._hana._hdbsql_connect = mock_hdbsql
+
+        self._hana.set_ini_parameter(
+            ini_parameter_values=[{'section_name':'memorymanager',
+            'parameter_name':'global_allocation_limit', 'parameter_value':'25000'}],
+            database='db', file_name='global.ini', layer='SYSTEM',
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_hdbsql.assert_called_once_with(
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_command.assert_called_once_with(
+            '{hdbsql} -d {db} '\
+            '\\"ALTER SYSTEM ALTER CONFIGURATION(\'{file_name}\', \'{layer}\') SET'
+            '{ini_parameter_values};\\"'.format(
+            hdbsql='hdbsql', db='db', file_name='global.ini', layer='SYSTEM',
+            ini_parameter_values='(\'memorymanager\',\'global_allocation_limit\')=\'25000\''))
+    
+    def test_set_ini_parameter_layer(self):
+        mock_command = mock.Mock()
+        self._hana._run_hana_command = mock_command
+        mock_hdbsql = mock.Mock(return_value='hdbsql')
+        self._hana._hdbsql_connect = mock_hdbsql
+
+        self._hana.set_ini_parameter(
+            ini_parameter_values=[{'section_name':'memorymanager',
+            'parameter_name':'global_allocation_limit', 'parameter_value':'25000'}],
+            database='db', file_name='global.ini',
+            layer='HOST', layer_name='host01',
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_hdbsql.assert_called_once_with(
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_command.assert_called_once_with(
+            '{hdbsql} -d {db} '\
+            '\\"ALTER SYSTEM ALTER CONFIGURATION(\'{file_name}\', \'{layer}\', \'{layer_name}\') '
+            'SET{ini_parameter_values};\\"'.format(
+            hdbsql='hdbsql', db='db', file_name='global.ini', 
+            layer='HOST', layer_name='host01',
+            ini_parameter_values='(\'memorymanager\',\'global_allocation_limit\')=\'25000\''))
+    
+    def test_set_ini_parameter_reconfig(self):
+        mock_command = mock.Mock()
+        self._hana._run_hana_command = mock_command
+        mock_hdbsql = mock.Mock(return_value='hdbsql')
+        self._hana._hdbsql_connect = mock_hdbsql
+
+        self._hana.set_ini_parameter(
+            ini_parameter_values=[{'section_name':'memorymanager',
+            'parameter_name':'global_allocation_limit', 'parameter_value':'25000'}],
+            database='db', file_name='global.ini', layer='SYSTEM',
+            reconfig=True, key_name='key', user_name='key_user', user_password='key_password')
+        mock_hdbsql.assert_called_once_with(
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_command.assert_called_once_with(
+            '{hdbsql} -d {db} '\
+            '\\"ALTER SYSTEM ALTER CONFIGURATION(\'{file_name}\', \'{layer}\') SET'
+            '{ini_parameter_values}{reconfig};\\"'.format(
+            hdbsql='hdbsql', db='db', file_name='global.ini', layer='SYSTEM',
+            ini_parameter_values='(\'memorymanager\',\'global_allocation_limit\')=\'25000\'',
+            reconfig=' WITH RECONFIGURE'))
+    
+    def test_unset_ini_parameter(self):
+        mock_command = mock.Mock()
+        self._hana._run_hana_command = mock_command
+        mock_hdbsql = mock.Mock(return_value='hdbsql')
+        self._hana._hdbsql_connect = mock_hdbsql
+
+        self._hana.unset_ini_parameter(
+            ini_parameter_names=[{'section_name':'memorymanager',
+            'parameter_name':'global_allocation_limit'}],
+            database='db', file_name='global.ini', layer='SYSTEM',
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_hdbsql.assert_called_once_with(
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_command.assert_called_once_with(
+            '{hdbsql} -d {db} '\
+            '\\"ALTER SYSTEM ALTER CONFIGURATION(\'{file_name}\', \'{layer}\') UNSET'
+            '{ini_parameter_names};\\"'.format(
+            hdbsql='hdbsql', db='db', file_name='global.ini', layer='SYSTEM',
+            ini_parameter_names='(\'memorymanager\',\'global_allocation_limit\')'))
+
+    def test_unset_ini_parameter_layer(self):
+        mock_command = mock.Mock()
+        self._hana._run_hana_command = mock_command
+        mock_hdbsql = mock.Mock(return_value='hdbsql')
+        self._hana._hdbsql_connect = mock_hdbsql
+
+        self._hana.unset_ini_parameter(
+            ini_parameter_names=[{'section_name':'memorymanager',
+            'parameter_name':'global_allocation_limit'}],
+            database='db', file_name='global.ini', layer='HOST', layer_name='host01',
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_hdbsql.assert_called_once_with(
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_command.assert_called_once_with(
+            '{hdbsql} -d {db} '\
+            '\\"ALTER SYSTEM ALTER CONFIGURATION(\'{file_name}\', \'{layer}\', \'{layer_name}\') UNSET'
+            '{ini_parameter_names};\\"'.format(
+            hdbsql='hdbsql', db='db', file_name='global.ini', layer='HOST', layer_name='host01',
+            ini_parameter_names='(\'memorymanager\',\'global_allocation_limit\')'))
+   
+    def test_unset_ini_parameter_reconfig(self):
+        mock_command = mock.Mock()
+        self._hana._run_hana_command = mock_command
+        mock_hdbsql = mock.Mock(return_value='hdbsql')
+        self._hana._hdbsql_connect = mock_hdbsql
+
+        self._hana.unset_ini_parameter(
+            ini_parameter_names=[{'section_name':'memorymanager',
+            'parameter_name':'global_allocation_limit'}],
+            database='db', file_name='global.ini', layer='SYSTEM', reconfig=True,
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_hdbsql.assert_called_once_with(
+            key_name='key', user_name='key_user', user_password='key_password')
+        mock_command.assert_called_once_with(
+            '{hdbsql} -d {db} '\
+            '\\"ALTER SYSTEM ALTER CONFIGURATION(\'{file_name}\', \'{layer}\') UNSET'
+            '{ini_parameter_names}{reconfig};\\"'.format(
+            hdbsql='hdbsql', db='db', file_name='global.ini', layer='SYSTEM',
+            ini_parameter_names='(\'memorymanager\',\'global_allocation_limit\')',
+            reconfig=' WITH RECONFIGURE'))
 
 _hdbnsutil_sr_state_outputs = {
     "Not set (HDB daemon stopped)": """nameserver hana01:30001 not responding.

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -406,7 +406,8 @@ class TestHana(unittest.TestCase):
 
     def test_hdbsql_connect_key(self):
         cmd = self._hana._hdbsql_connect(key_name='mykey')
-        self.assertEqual('hdbsql -U mykey', cmd)
+        expected_cmd = 'hdbsql -i {} -U mykey'.format(self._hana.inst)
+        self.assertEqual(expected_cmd, cmd)
 
     def test_hdbsql_connect_key_error(self):
         with self.assertRaises(ValueError) as err:
@@ -417,7 +418,8 @@ class TestHana(unittest.TestCase):
 
     def test_hdbsql_connect_userpass(self):
         cmd = self._hana._hdbsql_connect(user_name='user', user_password='pass')
-        self.assertEqual('hdbsql -u user -p pass', cmd)
+        expected_cmd = 'hdbsql -i {} -u user -p pass'.format(self._hana.inst)
+        self.assertEqual(expected_cmd, cmd)
 
     def test_hdbsql_connect_userpass_error(self):
         with self.assertRaises(ValueError) as err:
@@ -505,7 +507,7 @@ class TestHana(unittest.TestCase):
             self._hana._run_hana_command.assert_called_once_with(
                 'HDBSettings.sh systemReplicationStatus.py', exception=False)
             self.assertEqual(status, {"status": expect})
-
+    
 
 _hdbnsutil_sr_state_outputs = {
     "Not set (HDB daemon stopped)": """nameserver hana01:30001 not responding.


### PR DESCRIPTION
Creating a new PR will fewer commits and all the relevant code changes.
It includes:
1) Functions to change HANA ini file parameters:
- set_ini_parameter
- unset_ini_parameter
Both functions use a core function below which does majority of the work to construct commands with HANA SQL:
- _manage_ini_file

2) Unit tests for above functions
3) Also changes to hdbsql_connect  to consider 'instance no' parameter when connecting to specific HANA instances