### PR TITLE
Feature/update secondary registration

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 09:35:41 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
+
+- Update SR registration process. Now the methods retries the 
+  registration command until a successful return and copies the
+  SSFS files from the primary node as well 
+
+-------------------------------------------------------------------
 Tue Apr 23 11:04:53 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Remove enum34 dependency from code 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ SCRIPTS = []
 
 DEPENDENCIES = read('requirements.txt').split()
 
-PACKAGE_DATA = {}
+PACKAGE_DATA = {
+    'shaptools': ['support/ssh_askpass']
+}
 DATA_FILES = []
 
 

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -310,17 +310,19 @@ class HanaInstance:
         user = self.HANAUSER.format(sid=self.sid)
         sid_upper = self.sid.upper()
         cmd = \
-            "sshpass -p {passwd} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
+            "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
             "{user}@{remote_host}:/usr/sap/{sid}/SYS/global/security/rsecssfs/data/SSFS_{sid}.DAT "\
             "/usr/sap/{sid}/SYS/global/security/rsecssfs/data/SSFS_{sid}.DAT".format(
-                passwd=primary_pass, user=user, remote_host=remote_host, sid=sid_upper)
+                user=user, remote_host=remote_host, sid=sid_upper)
+        cmd = shell.create_ssh_askpass(primary_pass, cmd)
         self._run_hana_command(cmd)
 
         cmd = \
-            "sshpass -p {passwd} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
+            "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\
             "{user}@{remote_host}:/usr/sap/{sid}/SYS/global/security/rsecssfs/key/SSFS_{sid}.KEY "\
             "/usr/sap/{sid}/SYS/global/security/rsecssfs/key/SSFS_{sid}.KEY".format(
-                passwd=primary_pass, user=user, remote_host=remote_host, sid=sid_upper)
+                user=user, remote_host=remote_host, sid=sid_upper)
+        cmd = shell.create_ssh_askpass(primary_pass, cmd)
         self._run_hana_command(cmd)
 
     def sr_register_secondary(

--- a/shaptools/shell.py
+++ b/shaptools/shell.py
@@ -9,11 +9,13 @@ Module to interact with the shell commands.
 """
 
 import logging
+import os
 import subprocess
 import shlex
 import re
 
 LOGGER = logging.getLogger('shell')
+ASKPASS_SCRIPT = 'support/ssh_askpass'
 
 
 class ProcessResult:
@@ -78,6 +80,22 @@ def format_su_cmd(cmd, user):
         str: Formatted command
     """
     return 'su -lc "{cmd}" {user}'.format(cmd=cmd, user=user)
+
+
+def create_ssh_askpass(password, cmd):
+    """
+    Create ask pass command
+    Note: subprocess os.setsid doesn't work as the user might have a password
+
+    Args:
+        password (str): ssh command password
+        cmd (str): Command to run
+    """
+    dirname = os.path.dirname(__file__)
+    ask_pass_script = os.path.join(dirname, ASKPASS_SCRIPT)
+    ssh_askpass_str = 'export SSH_ASKPASS={};export PASS={};export DISPLAY=:0;setsid {}'.format(
+        ask_pass_script, password, cmd)
+    return ssh_askpass_str
 
 
 def execute_cmd(cmd, user=None, password=None):

--- a/shaptools/support/ssh_askpass
+++ b/shaptools/support/ssh_askpass
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "$PASS"

--- a/tests/shell_test.py
+++ b/tests/shell_test.py
@@ -172,3 +172,16 @@ class TestShell(unittest.TestCase):
         mock_process.assert_called_once_with('updated command', 5, b'out', b'err')
 
         self.assertEqual(mock_process_inst, result)
+
+    @mock.patch('os.path')
+    def test_create_ssh_askpass(self, mock_path):
+
+
+        mock_path.dirname.return_value = 'file'
+        mock_path.join.return_value = 'file/support/ssh_askpass'
+
+        result = shell.create_ssh_askpass('pass', 'my_command')
+
+        self.assertEqual(
+            'export SSH_ASKPASS=file/support/ssh_askpass;export PASS=pass;export DISPLAY=:0;setsid my_command',
+            result)


### PR DESCRIPTION
Update shaptools to perform the whole SR secondary registration process.

SSH_ASKPASS is used to connect the primary node and retrieve the SSFS files.