### PR TITLE
Remove BaseError and inherit from Exception instead

### DIFF
--- a/shaptools/hdb_connector/connectors/base_connector.py
+++ b/shaptools/hdb_connector/connectors/base_connector.py
@@ -11,12 +11,6 @@ Base connector
 import logging
 
 
-class BaseError(Exception):
-    """
-    Base exception
-    """
-
-
 class DriverNotAvailableError(Exception):
     """
     dbapi nor pyhdb are installed
@@ -29,7 +23,7 @@ class ConnectionError(Exception):
     """
 
 
-class QueryError(BaseError):
+class QueryError(Exception):
     """
     Error during query
     """


### PR DESCRIPTION
Not inheriting from the Exception class will cause some issues with Python3: `TypeError: catching classes that do not inherit from BaseException is not allowed`