### PR TITLE
Feature/netweaver ers

### DIFF
--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -9,6 +9,7 @@ SAP Netweaver management module
 """
 
 import logging
+import time
 
 from shaptools import shell
 
@@ -33,14 +34,17 @@ class NetweaverInstance(object):
         sid (str): SAP Netweaver sid
         inst (str): SAP Netweaver instance number
         password (str): Netweaver instance password
+        remote_host (str, opt): Remote host where the command will be executed
     """
 
     # SID is usualy written uppercased, but the OS user is always created lower case.
     NETWEAVER_USER = '{sid}adm'.lower()
     UNINSTALL_PRODUCT = 'NW_Uninstall:GENERIC.IND.PD'
     GETPROCESSLIST_SUCCESS_CODES = [0, 3, 4]
+    SUCCESSFULLY_INSTALLED = 0
+    UNSPECIFIED_ERROR = 111
 
-    def __init__(self, sid, inst, password):
+    def __init__(self, sid, inst, password, **kwargs):
         # Force instance nr always with 2 positions.
         inst = '{:0>2}'.format(inst)
         if not all(isinstance(i, basestring) for i in [sid, inst, password]):
@@ -51,28 +55,56 @@ class NetweaverInstance(object):
         self.sid = sid
         self.inst = inst
         self._password = password
+        self.remote_host = kwargs.get('remote_host', None)
 
-    def _execute_sapcontrol(self, sapcontrol_function, exception=True):
+    def _execute_sapcontrol(self, sapcontrol_function, **kwargs):
         """
         Execute sapcontrol commands and return result
 
         Args:
             sapcontrol_function (str): sapcontrol function
             exception (boolean): Raise NetweaverError non-zero return code (default true)
+            host (str, optional): Host where the command will be executed
+            inst (str, optional): Use a different instance number
+            user (str, optional): Define a different user for the command
+            password (str, optional): The new user password
 
         Returns:
             ProcessResult: ProcessResult instance storing subprocess returncode,
                 stdout and stderr
         """
+        exception = kwargs.get('exception', True)
+        # The -host and -user parameters are used in sapcontrol to authorize commands execution
+        # in remote host Netweaver instances
+        host = kwargs.get('host', None)
+        inst = kwargs.get('inst', self.inst)
+        user = kwargs.get('user', None)
+        password = kwargs.get('password', None)
+        if user and not password:
+            raise NetweaverError('Password must be provided together with user')
+
+        host_str = '-host {} '.format(host) if host else ''
+        user_str = '-user {} {} '.format(user, password) if user else ''
+
         user = self.NETWEAVER_USER.format(sid=self.sid)
-        cmd = 'sapcontrol -nr {instance} -function {sapcontrol_function}'.format(
-            instance=self.inst, sapcontrol_function=sapcontrol_function)
-        result = shell.execute_cmd(cmd, user, self._password)
+        cmd = 'sapcontrol {host}{user}-nr {instance} -function {sapcontrol_function}'.format(
+            host=host_str, user=user_str, instance=inst, sapcontrol_function=sapcontrol_function)
+
+        result = shell.execute_cmd(cmd, user, self._password, self.remote_host)
 
         if exception and result.returncode != 0:
             raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
 
         return result
+
+    @staticmethod
+    def get_attribute_from_file(conf_file, attribute_pattern):
+        """
+        Get attribute from file using a pattern
+        """
+        with open(conf_file, 'r') as file_content:
+            attribute_data = shell.find_pattern(attribute_pattern, file_content.read())
+        return attribute_data
 
     @staticmethod
     def _is_ascs_installed(processes):
@@ -116,16 +148,24 @@ class NetweaverInstance(object):
             raise ValueError('provided sap instance type is not valid: {}'.format(sap_instance))
 
     @classmethod
-    def install(cls, software_path, virtual_host, product_id, conf_file, root_user, password):
+    def install(
+            cls, software_path, virtual_host, product_id, conf_file, root_user, password, **kwargs):
         """
         Install SAP Netweaver instance
 
         Args:
             software_path (str): Path where SAP Netweaver 'sapinst' tool is located
+            virtual_host (str): Virtual host name of the machine
+            product_id (str): SAP instance product id
             conf_file (str): Path to the configuration file
             root_user (str): Root user name
             password (str): Root user password
+            exception (bool, opt): Raise and exception in case of error if True, return result
+                object otherwise
+            remote_host (str, opt): Remote host where the command will be executed
         """
+        raise_exception = kwargs.get('exception', True)
+        remote_host = kwargs.get('remote_host', None)
 
         cmd = '{software_path}/sapinst SAPINST_USE_HOSTNAME={virtual_host} '\
             'SAPINST_EXECUTE_PRODUCT_ID={product_id} '\
@@ -135,31 +175,174 @@ class NetweaverInstance(object):
                 virtual_host=virtual_host,
                 product_id=product_id,
                 conf_file=conf_file)
-        result = shell.execute_cmd(cmd, root_user, password)
-        if result.returncode:
+        result = shell.execute_cmd(cmd, root_user, password, remote_host)
+        if result.returncode and raise_exception:
             raise NetweaverError('SAP Netweaver installation failed')
+        return result
 
-    def uninstall(self, software_path, virtual_host, conf_file, root_user, password):
+    @classmethod
+    def _ascs_restart_needed(cls, installation_result):
+        """
+        Check the ERS installation return code and output to see if the ASCS instance restart
+        is needed
+
+        Args:
+            installation_result (shell.ProcessResult): ERS installation result
+
+        Returns: True if ASCS restart is needed, False otherwise
+        """
+        expected_msg = \
+            '<html><p>Error when stopping instance.</p><p>Cannot stop instance <i>(.*)'\
+            '</i> on host <i>(.*)</i>.</p><p>Stop the instance manually and choose <i>OK</i> to '\
+            'continue.</html>'
+        if installation_result.returncode == cls.UNSPECIFIED_ERROR:
+            if shell.find_pattern(expected_msg, installation_result.output):
+                return True
+        return False
+
+    @classmethod
+    def _restart_ascs(cls, conf_file, ers_pass, ascs_pass, remote_host=None):
+        """
+        Restart ascs from the ERS host.
+
+        Args:
+            conf_file (str): Path to the configuration file
+            ascs_pass (str): ASCS instance password
+            remote_host (str, optional): Remote host where the command will be executed
+        """
+        # Get sid and instance number from configuration file
+        sid = cls.get_attribute_from_file(
+            conf_file, 'NW_readProfileDir.profileDir += +.*/(.*)/profile').group(1).lower()
+        instance_number = cls.get_attribute_from_file(
+            conf_file, 'nw_instance_ers.ersInstanceNumber += +(.*)').group(1)
+        ers = cls(sid, instance_number, ers_pass, remote_host=remote_host)
+        result = ers.get_system_instances(exception=False)
+        ascs_data = shell.find_pattern(
+            '(.*), (.*), (.*), (.*), (.*), MESSAGESERVER|ENQUE, GREEN', result.output)
+
+        ascs_user = '{}adm'.format(sid).lower()
+        ascs_hostname = ascs_data.group(1)
+        ascs_instance_number = ascs_data.group(2)
+
+        ers.stop(host=ascs_hostname, inst=ascs_instance_number, user=ascs_user, password=ascs_pass)
+        ers.start(host=ascs_hostname, inst=ascs_instance_number, user=ascs_user, password=ascs_pass)
+
+    @classmethod
+    def install_ers(
+            cls, software_path, virtual_host, product_id, conf_file, root_user, password, **kwargs):
+        """
+        Install SAP Netweaver ERS instance. ERS instance installation needs an active polling
+        the instance where the ASCS is installed.
+
+        Args:
+            software_path (str): Path where SAP Netweaver 'sapinst' tool is located
+            virtual_host (str): Virtual host name of the machine
+            product_id (str): SAP instance product id
+            conf_file (str): Path to the configuration file
+            root_user (str): Root user name
+            password (str): Root user password
+            ascs_password (str, optional): Password of the SAP user in the machine hosting the
+                ASCS instance. If it's not set the same password used to install ERS will be used
+            timeout (int, optional): Timeout of the installation process. If 0 it will try to
+                install the instance only once
+            interval (int, optional): Retry interval in seconds
+            remote_host (str, opt): Remote host where the command will be executed
+        """
+        timeout = kwargs.get('timeout', 0)
+        interval = kwargs.get('interval', 5)
+        ers_pass = cls.get_attribute_from_file(
+            conf_file, 'nwUsers.sidadmPassword += +(.*)').group(1)
+        ascs_pass = kwargs.get('ascs_password', ers_pass)
+        remote_host = kwargs.get('remote_host', None)
+
+        current_time = time.clock()
+        current_timeout = current_time + timeout
+        while current_time <= current_timeout:
+            result = NetweaverInstance.install(
+                software_path, virtual_host, product_id, conf_file, root_user, password,
+                exception=False, remote_host=remote_host)
+
+            if result.returncode == cls.SUCCESSFULLY_INSTALLED or \
+                    cls._ascs_restart_needed(result):
+                cls._restart_ascs(conf_file, ers_pass, ascs_pass, remote_host)
+                break
+
+            time.sleep(interval)
+            current_time = time.clock()
+        else:
+            raise NetweaverError(
+                'SAP Netweaver ERS installation failed after {} seconds'.format(timeout))
+
+    def uninstall(self, software_path, virtual_host, conf_file, root_user, password, **kwargs):
         """
         Uninstall SAP Netweaver instance
 
         Args:
             software_path (str): Path where SAP Netweaver 'sapinst' tool is located
+            virtual_host (str): Virtual host name of the machine
             conf_file (str): Path to the configuration file
             root_user (str): Root user name
             password (str): Root user password
+            remote_host (str, opt): Remote host where the command will be executed
         """
+        remote_host = kwargs.get('remote_host', None)
         user = self.NETWEAVER_USER.format(sid=self.sid)
         self.install(
-            software_path, virtual_host, self.UNINSTALL_PRODUCT, conf_file, root_user, password)
+            software_path, virtual_host, self.UNINSTALL_PRODUCT, conf_file, root_user, password,
+            remote_host=remote_host)
         shell.remove_user(user, True, root_user, password)
 
-    def get_process_list(self, exception=True):
+    def get_process_list(self, exception=True, **kwargs):
         """
         Get SAP processes list
         """
-        result = self._execute_sapcontrol('GetProcessList', exception=False)
+        result = self._execute_sapcontrol('GetProcessList', exception=False, **kwargs)
         if exception and result.returncode not in self.GETPROCESSLIST_SUCCESS_CODES:
             raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
-
         return result
+
+    def get_system_instances(self, exception=True, **kwargs):
+        """
+        Get SAP system instances list
+        """
+        result = self._execute_sapcontrol('GetSystemInstanceList', exception=False, **kwargs)
+        if exception and result.returncode:
+            raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
+        return result
+
+    def get_instance_properties(self, exception=True, **kwargs):
+        """
+        Get SAP instance properties
+        """
+        result = self._execute_sapcontrol('GetInstanceProperties', exception=False, **kwargs)
+        if exception and result.returncode:
+            raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
+        return result
+
+    def start(self, wait=15, delay=0, **kwargs):
+        """
+        Start SAP instance
+        Args:
+            wait (int): Time to wait until the processes are started in seconds
+        """
+        if wait:
+            cmd = 'StartWait {} {}'.format(wait, delay)
+        else:
+            cmd = 'Start'
+        result = self._execute_sapcontrol(cmd, exception=False, **kwargs)
+        if result.returncode:
+            raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
+
+    def stop(self, wait=15, delay=0, **kwargs):
+        """
+        Stop SAP instance
+        Args:
+            wait (int): Time to wait until the processes are stopped in seconds
+        """
+        if wait:
+            cmd = 'StopWait {} {}'.format(wait, delay)
+        else:
+            cmd = 'Stop'
+        result = self._execute_sapcontrol(cmd, exception=False, **kwargs)
+        if result.returncode:
+            raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -258,7 +258,7 @@ class NetweaverInstance(object):
         current_time = time.clock()
         current_timeout = current_time + timeout
         while current_time <= current_timeout:
-            result = NetweaverInstance.install(
+            result = cls.install(
                 software_path, virtual_host, product_id, conf_file, root_user, password,
                 exception=False, remote_host=remote_host)
 
@@ -319,7 +319,7 @@ class NetweaverInstance(object):
             raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
         return result
 
-    def start(self, wait=15, delay=0, **kwargs):
+    def start(self, wait=15, delay=0, exception=True, **kwargs):
         """
         Start SAP instance
         Args:
@@ -330,10 +330,11 @@ class NetweaverInstance(object):
         else:
             cmd = 'Start'
         result = self._execute_sapcontrol(cmd, exception=False, **kwargs)
-        if result.returncode:
+        if exception and result.returncode:
             raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
+        return result
 
-    def stop(self, wait=15, delay=0, **kwargs):
+    def stop(self, wait=15, delay=0, exception=True, **kwargs):
         """
         Stop SAP instance
         Args:
@@ -344,5 +345,6 @@ class NetweaverInstance(object):
         else:
             cmd = 'Stop'
         result = self._execute_sapcontrol(cmd, exception=False, **kwargs)
-        if result.returncode:
+        if exception and result.returncode:
             raise NetweaverError('Error running sapcontrol command: {}'.format(result.cmd))
+        return result

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -290,7 +290,7 @@ class NetweaverInstance(object):
         self.install(
             software_path, virtual_host, self.UNINSTALL_PRODUCT, conf_file, root_user, password,
             remote_host=remote_host)
-        shell.remove_user(user, True, root_user, password)
+        shell.remove_user(user, True, root_user, password, remote_host)
 
     def get_process_list(self, exception=True, **kwargs):
         """

--- a/shaptools/shell.py
+++ b/shaptools/shell.py
@@ -164,17 +164,18 @@ def execute_cmd(cmd, user=None, password=None, remote_host=None):
 
     return result
 
-def remove_user(user, force=False, root_user=None, root_password=None):
+def remove_user(user, force=False, root_user=None, root_password=None, remote_host=None):
     """
     Remove user from system
     Args:
         user (str): User to remove
         force (bool): Force the remove process even though the user is used in some process
+        remote_host (str, opt): Remote host where the command will be executed
     """
     cmd = 'userdel {}'.format(user)
     process_executing = r'userdel: user {} is currently used by process (.*)'.format(user)
     while True:
-        result = execute_cmd(cmd, root_user, root_password)
+        result = execute_cmd(cmd, root_user, root_password, remote_host)
         if result.returncode == 0:
             return
         elif force:
@@ -182,7 +183,7 @@ def remove_user(user, force=False, root_user=None, root_password=None):
             if not process_pid:
                 break
             kill_cmd = 'kill -9 {}'.format(process_pid.group(1))
-            execute_cmd(kill_cmd, root_user, root_password)
+            execute_cmd(kill_cmd, root_user, root_password, remote_host)
         else:
             break
     raise ShellError('error removing user {}'.format(user))

--- a/tests/netweaver_test.py
+++ b/tests/netweaver_test.py
@@ -57,8 +57,11 @@ class TestNetweaver(unittest.TestCase):
         """
 
     def test_init(self):
-        self._netweaver = netweaver.NetweaverInstance('ha1', 1, 'pass')
+        self._netweaver = netweaver.NetweaverInstance('ha1', 1, 'pass', remote_host='remote')
+        self.assertEqual('ha1', self._netweaver.sid)
         self.assertEqual('01', self._netweaver.inst)
+        self.assertEqual('pass', self._netweaver._password)
+        self.assertEqual('remote', self._netweaver.remote_host)
 
         with self.assertRaises(TypeError) as err:
             self._netweaver = netweaver.NetweaverInstance(1, '00', 'pass')
@@ -92,6 +95,28 @@ class TestNetweaver(unittest.TestCase):
         self.assertEqual(proc_mock, result)
 
     @mock.patch('shaptools.shell.execute_cmd')
+    def test_execute_sapcontrol_full(self, mock_execute):
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 0
+
+        mock_execute.return_value = proc_mock
+
+        result = self._netweaver._execute_sapcontrol(
+            'mycommand', host='otherhost', user='newuser', password='newpass')
+
+        cmd = 'sapcontrol -host otherhost -user newuser newpass -nr 00 -function mycommand'
+        mock_execute.assert_called_once_with(cmd, 'ha1adm', 'pass', None)
+        self.assertEqual(proc_mock, result)
+
+
+    def test_execute_sapcontrol_pass_missing(self):
+
+        with self.assertRaises(netweaver.NetweaverError) as err:
+            self._netweaver._execute_sapcontrol('mycommand', user='user')
+
+        self.assertTrue('Password must be provided together with user')
+
+    @mock.patch('shaptools.shell.execute_cmd')
     def test_execute_sapcontrol_error(self, mock_execute):
         cmd = 'sapcontrol -nr 00 -function mycommand'
         proc_mock = mock.Mock()
@@ -118,6 +143,14 @@ class TestNetweaver(unittest.TestCase):
 
         mock_execute.assert_called_once_with(cmd, 'ha1adm', 'pass', None)
         self.assertEqual(proc_mock, result)
+
+    @mock.patch('shaptools.shell.find_pattern')
+    def test_get_attribute_from_file(self, mock_find_pattern):
+        mock_find_pattern.return_value = 'found_attr'
+        with mock.patch('shaptools.netweaver.open', mock.mock_open(read_data='filecontent')) as mock_open:
+            attr = netweaver.NetweaverInstance.get_attribute_from_file('file', 'attr')
+        mock_find_pattern.assert_called_once_with('attr', 'filecontent')
+        self.assertEqual('found_attr', attr)
 
     @mock.patch('shaptools.shell.find_pattern')
     def test_is_ascs_installed(self, mock_find_pattern):
@@ -242,9 +275,257 @@ class TestNetweaver(unittest.TestCase):
         mock_execute_cmd.assert_called_once_with(cmd, 'root', 'pass', 'remote')
         self.assertTrue('SAP Netweaver installation failed' in str(err.exception))
 
+    @mock.patch('shaptools.netweaver.shell.find_pattern')
+    def test_ascs_restart_needed(self, mock_find_pattern):
+
+        installation_result = mock.Mock()
+        installation_result.returncode = netweaver.NetweaverInstance.UNSPECIFIED_ERROR
+        installation_result.output = 'output'
+        mock_find_pattern.return_value = True
+
+        result = netweaver.NetweaverInstance._ascs_restart_needed(installation_result)
+        self.assertTrue(result)
+
+        mock_find_pattern.reset_mock()
+        installation_result = mock.Mock()
+        installation_result.returncode = netweaver.NetweaverInstance.UNSPECIFIED_ERROR
+        installation_result.output = 'output'
+        mock_find_pattern.return_value = False
+
+        result = netweaver.NetweaverInstance._ascs_restart_needed(installation_result)
+        self.assertFalse(result)
+
+        installation_result = mock.Mock()
+        installation_result.returncode = 0
+
+        result = netweaver.NetweaverInstance._ascs_restart_needed(installation_result)
+        self.assertFalse(result)
+
+    @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
+    @mock.patch('shaptools.netweaver.shell.find_pattern')
+    def test_restart_ascs(self, mock_find_pattern, mock_get_attribute):
+        mock_result1 = mock.Mock()
+        mock_result1.group.return_value = 'HA1'
+
+        mock_result2 = mock.Mock()
+        mock_result2.group.return_value = '00'
+        mock_get_attribute.side_effect = [mock_result1, mock_result2]
+
+        mock_ascs_data = mock.Mock()
+        mock_ascs_data.group.side_effect = ['ascs_hostname', 'ascs_inst']
+        mock_find_pattern.return_value = mock_ascs_data
+
+        # This patch.object tree is used to mock an instance of the class without mocking the class
+        # methods
+        with mock.patch.object(netweaver.NetweaverInstance, "__init__") as mock_instance:
+            mock_instance.return_value = None
+            with mock.patch.object(netweaver.NetweaverInstance, "get_system_instances") as mock_get_system_instances:
+                mock_result = mock.Mock(output='output')
+                mock_get_system_instances.return_value = mock_result
+                with mock.patch.object(netweaver.NetweaverInstance, "stop") as mock_stop:
+                    with mock.patch.object(netweaver.NetweaverInstance, "start") as mock_start:
+                        netweaver.NetweaverInstance._restart_ascs('conf_file', 'ers_pass', 'ascs_pass')
+
+        mock_get_attribute.assert_has_calls([
+            mock.call('conf_file',  'NW_readProfileDir.profileDir += +.*/(.*)/profile'),
+            mock.call('conf_file',  'nw_instance_ers.ersInstanceNumber += +(.*)')
+        ])
+        mock_result1.group.assert_called_once_with(1)
+        mock_result2.group.assert_called_once_with(1)
+
+        mock_instance.assert_called_once_with('ha1', '00', 'ers_pass', remote_host=None)
+
+        mock_get_system_instances.assert_called_once_with(exception=False)
+
+        mock_find_pattern.assert_called_once_with(
+            '(.*), (.*), (.*), (.*), (.*), MESSAGESERVER|ENQUE, GREEN', 'output')
+
+        mock_ascs_data.group.assert_has_calls([
+            mock.call(1), mock.call(2)
+        ])
+        mock_stop.assert_called_once_with(
+            host='ascs_hostname', inst='ascs_inst', user='ha1adm', password='ascs_pass')
+        mock_start.assert_called_once_with(
+            host='ascs_hostname', inst='ascs_inst', user='ha1adm', password='ascs_pass')
+
+    @mock.patch('time.clock')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.install')
+    @mock.patch('shaptools.netweaver.NetweaverInstance._ascs_restart_needed')
+    @mock.patch('shaptools.netweaver.NetweaverInstance._restart_ascs')
+    def test_install_ers_first_install(
+            self, mock_restart, mock_restart_needed, mock_install,
+            mock_get_attribute, mock_clock):
+
+        mock_result = mock.Mock()
+        mock_result.group.return_value = 'ers_pass'
+        mock_get_attribute.return_value = mock_result
+
+        mock_clock.return_value = 1
+        mock_install_result = mock.Mock(returncode=111)
+        mock_install.return_value = mock_install_result
+        mock_restart_needed.return_value = True
+
+        netweaver.NetweaverInstance.install_ers(
+            'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+            ascs_password='ascs_pass', timeout=5, interval=1)
+
+        mock_result.group.assert_called_once_with(1)
+        mock_install.assert_called_once_with(
+            'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+            exception=False, remote_host=None)
+        mock_restart_needed.assert_called_once_with(mock_install_result)
+        mock_restart.assert_called_once_with('conf_file', 'ers_pass', 'ascs_pass', None)
+
+    @mock.patch('time.clock')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.install')
+    @mock.patch('shaptools.netweaver.NetweaverInstance._ascs_restart_needed')
+    @mock.patch('shaptools.netweaver.NetweaverInstance._restart_ascs')
+    def test_install_ers_loop_install(
+            self, mock_restart, mock_restart_needed, mock_install,
+            mock_get_attribute, mock_sleep, mock_clock):
+
+        mock_result = mock.Mock()
+        mock_result.group.return_value = 'ers_pass'
+        mock_get_attribute.return_value = mock_result
+
+        mock_clock.side_effect = [1, 2, 3, 4, 5]
+        mock_install_result = mock.Mock(returncode=111)
+        mock_install.side_effect = [mock_install_result, mock_install_result, mock_install_result]
+        mock_restart_needed.side_effect = [False, False, True]
+
+        netweaver.NetweaverInstance.install_ers(
+            'software', 'myhost', 'product', 'conf_file', 'user', 'pass', timeout=5, interval=1)
+
+        mock_result.group.assert_called_once_with(1)
+
+        mock_install.assert_has_calls([
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None),
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None),
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None)
+        ])
+        mock_restart_needed.assert_has_calls([
+            mock.call(mock_install_result),
+            mock.call(mock_install_result),
+            mock.call(mock_install_result)
+        ])
+        mock_restart.assert_called_once_with('conf_file', 'ers_pass', 'ers_pass', None)
+        mock_clock.assert_has_calls([
+            mock.call(),
+            mock.call(),
+            mock.call()
+        ])
+        mock_sleep.assert_has_calls([
+            mock.call(1),
+            mock.call(1)
+        ])
+
+    @mock.patch('time.clock')
+    @mock.patch('time.sleep')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.install')
+    @mock.patch('shaptools.netweaver.NetweaverInstance._ascs_restart_needed')
+    @mock.patch('shaptools.netweaver.NetweaverInstance._restart_ascs')
+    def test_install_ers_loop_install(
+            self, mock_restart, mock_restart_needed, mock_install,
+            mock_get_attribute, mock_sleep, mock_clock):
+
+        mock_result = mock.Mock()
+        mock_result.group.return_value = 'ers_pass'
+        mock_get_attribute.return_value = mock_result
+
+        mock_clock.side_effect = [1, 2, 3, 4, 5]
+        mock_install_result = mock.Mock(returncode=111)
+        mock_install.side_effect = [mock_install_result, mock_install_result, mock_install_result]
+        mock_restart_needed.side_effect = [False, False, True]
+
+        netweaver.NetweaverInstance.install_ers(
+            'software', 'myhost', 'product', 'conf_file', 'user', 'pass', timeout=5, interval=1)
+
+        mock_result.group.assert_called_once_with(1)
+
+        mock_install.assert_has_calls([
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None),
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None),
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None)
+        ])
+        mock_restart_needed.assert_has_calls([
+            mock.call(mock_install_result),
+            mock.call(mock_install_result),
+            mock.call(mock_install_result)
+        ])
+        mock_restart.assert_called_once_with('conf_file', 'ers_pass', 'ers_pass', None)
+        self.assertEqual(mock_clock.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        mock_sleep.assert_has_calls([
+            mock.call(1),
+            mock.call(1)
+        ])
+
+    @mock.patch('time.clock')
+    @mock.patch('time.sleep')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
+    @mock.patch('shaptools.netweaver.NetweaverInstance.install')
+    @mock.patch('shaptools.netweaver.NetweaverInstance._ascs_restart_needed')
+    def test_install_ers_error_install(
+            self, mock_restart_needed, mock_install,
+            mock_get_attribute, mock_sleep, mock_clock):
+
+        mock_result = mock.Mock()
+        mock_result.group.return_value = 'ers_pass'
+        mock_get_attribute.return_value = mock_result
+
+        mock_clock.side_effect = [1, 2, 3, 5]
+        mock_install_result = mock.Mock(returncode=111)
+        mock_install.side_effect = [mock_install_result, mock_install_result, mock_install_result]
+        mock_restart_needed.side_effect = [False, False, False]
+
+        with self.assertRaises(netweaver.NetweaverError) as err:
+            netweaver.NetweaverInstance.install_ers(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass', timeout=3, interval=1)
+        self.assertTrue('SAP Netweaver ERS installation failed after 3 seconds' in str(err.exception))
+
+        mock_result.group.assert_called_once_with(1)
+
+        mock_install.assert_has_calls([
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None),
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None),
+            mock.call(
+                'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
+                exception=False, remote_host=None)
+        ])
+        mock_restart_needed.assert_has_calls([
+            mock.call(mock_install_result),
+            mock.call(mock_install_result),
+            mock.call(mock_install_result)
+        ])
+        self.assertEqual(mock_clock.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 3)
+        mock_sleep.assert_has_calls([
+            mock.call(1),
+            mock.call(1),
+            mock.call(1)
+        ])
+
     @mock.patch('shaptools.shell.remove_user')
     def test_uninstall(self, mock_remove_user):
-
         self._netweaver.install = mock.Mock()
         self._netweaver.uninstall(
             '/path', 'virtual', '/inifile.params', 'root', 'pass', remote_host='remote')
@@ -285,4 +566,88 @@ class TestNetweaver(unittest.TestCase):
             self._netweaver.get_process_list()
         self._netweaver._execute_sapcontrol.assert_called_once_with(
             'GetProcessList', exception=False)
+        self.assertTrue('Error running sapcontrol command: updated command' in str(err.exception))
+
+    def test_get_system_instances(self):
+        mock_result = mock.Mock(returncode=0)
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        result = self._netweaver.get_system_instances(host='host')
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'GetSystemInstanceList', exception=False, host='host')
+        self.assertEqual(mock_result, result)
+
+    def test_get_system_instances_error(self):
+        mock_result = mock.Mock(returncode=1, cmd='updated command')
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        with self.assertRaises(netweaver.NetweaverError) as err:
+            self._netweaver.get_system_instances()
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'GetSystemInstanceList', exception=False)
+        self.assertTrue('Error running sapcontrol command: updated command' in str(err.exception))
+
+    def test_get_instance_properties(self):
+        mock_result = mock.Mock(returncode=0)
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        result = self._netweaver.get_instance_properties(host='host')
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'GetInstanceProperties', exception=False, host='host')
+        self.assertEqual(mock_result, result)
+
+    def test_get_instance_properties_error(self):
+        mock_result = mock.Mock(returncode=1, cmd='updated command')
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        with self.assertRaises(netweaver.NetweaverError) as err:
+            self._netweaver.get_instance_properties()
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'GetInstanceProperties', exception=False)
+        self.assertTrue('Error running sapcontrol command: updated command' in str(err.exception))
+
+    def test_start(self):
+        mock_result = mock.Mock(returncode=0)
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        result = self._netweaver.start(wait=0, host='host')
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'Start', exception=False, host='host')
+        self.assertEqual(mock_result, result)
+
+    def test_start_wait(self):
+        mock_result = mock.Mock(returncode=0)
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        result = self._netweaver.start(wait=5, host='host')
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'StartWait 5 0', exception=False, host='host')
+        self.assertEqual(mock_result, result)
+
+    def test_start_error(self):
+        mock_result = mock.Mock(returncode=1, cmd='updated command')
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        with self.assertRaises(netweaver.NetweaverError) as err:
+            self._netweaver.start(wait=5)
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'StartWait 5 0', exception=False)
+        self.assertTrue('Error running sapcontrol command: updated command' in str(err.exception))
+
+    def test_stop(self):
+        mock_result = mock.Mock(returncode=0)
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        result = self._netweaver.stop(wait=0, host='host')
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'Stop', exception=False, host='host')
+        self.assertEqual(mock_result, result)
+
+    def test_stop_wait(self):
+        mock_result = mock.Mock(returncode=0)
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        result = self._netweaver.stop(wait=5, host='host')
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'StopWait 5 0', exception=False, host='host')
+        self.assertEqual(mock_result, result)
+
+    def test_stop_error(self):
+        mock_result = mock.Mock(returncode=1, cmd='updated command')
+        self._netweaver._execute_sapcontrol = mock.Mock(return_value=mock_result)
+        with self.assertRaises(netweaver.NetweaverError) as err:
+            self._netweaver.stop(wait=5)
+        self._netweaver._execute_sapcontrol.assert_called_once_with(
+            'StopWait 5 0', exception=False)
         self.assertTrue('Error running sapcontrol command: updated command' in str(err.exception))

--- a/tests/shell_test.py
+++ b/tests/shell_test.py
@@ -240,9 +240,9 @@ class TestShell(unittest.TestCase):
         result = mock.Mock(returncode=0)
         mock_execute_cmd.return_value = result
 
-        shell.remove_user('user', False, 'root', 'pass')
+        shell.remove_user('user', False, 'root', 'pass', 'remote_host')
 
-        mock_execute_cmd.assert_called_once_with('userdel user', 'root', 'pass')
+        mock_execute_cmd.assert_called_once_with('userdel user', 'root', 'pass', 'remote_host')
 
     @mock.patch('shaptools.shell.execute_cmd')
     def test_remove_user_force(self, mock_execute_cmd):
@@ -255,11 +255,11 @@ class TestShell(unittest.TestCase):
         shell.remove_user('user', True, 'root', 'pass')
 
         mock_execute_cmd.assert_has_calls([
-            mock.call('userdel user', 'root', 'pass'),
-            mock.call('kill -9 1', 'root', 'pass'),
-            mock.call('userdel user', 'root', 'pass'),
-            mock.call('kill -9 2', 'root', 'pass'),
-            mock.call('userdel user', 'root', 'pass'),
+            mock.call('userdel user', 'root', 'pass', None),
+            mock.call('kill -9 1', 'root', 'pass', None),
+            mock.call('userdel user', 'root', 'pass', None),
+            mock.call('kill -9 2', 'root', 'pass', None),
+            mock.call('userdel user', 'root', 'pass', None),
         ])
 
     @mock.patch('shaptools.shell.execute_cmd')
@@ -271,7 +271,7 @@ class TestShell(unittest.TestCase):
         with self.assertRaises(shell.ShellError) as err:
             shell.remove_user('user', False, 'root', 'pass')
 
-        mock_execute_cmd.assert_called_once_with('userdel user', 'root', 'pass')
+        mock_execute_cmd.assert_called_once_with('userdel user', 'root', 'pass', None)
         self.assertTrue('error removing user user' in str(err.exception))
 
     @mock.patch('shaptools.shell.execute_cmd')
@@ -286,8 +286,8 @@ class TestShell(unittest.TestCase):
             shell.remove_user('user', True, 'root', 'pass')
 
         mock_execute_cmd.assert_has_calls([
-            mock.call('userdel user', 'root', 'pass'),
-            mock.call('kill -9 1', 'root', 'pass'),
-            mock.call('userdel user', 'root', 'pass')
+            mock.call('userdel user', 'root', 'pass', None),
+            mock.call('kill -9 1', 'root', 'pass', None),
+            mock.call('userdel user', 'root', 'pass', None)
         ])
         self.assertTrue('error removing user user' in str(err.exception))


### PR DESCRIPTION
Create the required code to install Netweaver ERS instance.

By now this is the implementation logic:

1. When install_ers is called, it will start a loop where it will try to install ERS in the node
2. If it fails with unknown errors it will continue
3. If it finishes with a successful error code (0), it will restart the ASCS instance in the first host
4. If it finishes with the error code 111 and the log output says that a manual ASCS is needed, it will restart the ASCS instance in the first host

To restart the ASCS node in the first node `sapcontrol` is used providing the `host` and `user` parameters.

Right now, the ERS installation prints a lot of logs (each failure is printed). This might be changed in the future to just print the last result (for example)

*IMPORTANT: We still need to exactly know if the `sapinst` installation wizard does some operation during the moment where ASCS restart is requested. In our case, after the `sapinst` execution finishes, we just restart the ASCS instance, that's it. Apparently the installation looks successful, but we should confirm just in case.*

