### PR TITLE
Feature/db pas instances

### DIFF
--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -376,7 +376,7 @@ class HanaInstance(object):
               '--remoteInstance={} --replicationMode={} --operationMode={}'.format(
                   name, remote_host, remote_instance, replication_mode, operation_mode)
 
-        current_time = time.clock()
+        current_time = time.time()
         current_timeout = current_time + timeout
         while current_time <= current_timeout:
             return_code = self._run_hana_command(cmd, False).returncode
@@ -387,7 +387,7 @@ class HanaInstance(object):
                 self._run_hana_command(cmd)
                 break
             time.sleep(interval)
-            current_time = time.clock()
+            current_time = time.time()
             continue
         else:
             raise HanaError(

--- a/shaptools/hdb_connector/connectors/pyhdb_connector.py
+++ b/shaptools/hdb_connector/connectors/pyhdb_connector.py
@@ -47,7 +47,7 @@ class PyhdbConnector(base_connector.BaseConnector):
                 user=kwargs.get('user'),
                 password=kwargs.get('password'),
             )
-        except socket.error as err:
+        except (socket.error, pyhdb.exceptions.DatabaseError) as err:
             raise base_connector.ConnectionError('connection failed: {}'.format(err))
         self._logger.info('connected successfully')
 

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -160,6 +160,19 @@ class NetweaverInstance(object):
         else:
             raise ValueError('provided sap instance type is not valid: {}'.format(sap_instance))
 
+    @staticmethod
+    def _remove_old_files(cwd, root_user, password, remote_host):
+        """
+        Remove old files from SAP installation cwd folder. Only start_dir.cd must remain
+        """
+        # TODO: check start_dir.cd exists
+        remove_files_cmd = "printf '%q ' {}/*".format(cwd)
+        remove_files = shell.execute_cmd(
+            remove_files_cmd, root_user, password, remote_host)
+        remove_files = remove_files.output.replace('{}/start_dir.cd'.format(cwd), '')
+        cmd = 'rm -rf {}'.format(remove_files)
+        shell.execute_cmd(cmd, root_user, password, remote_host)
+
     @classmethod
     def install(
             cls, software_path, virtual_host, product_id, conf_file, root_user, password, **kwargs):
@@ -173,21 +186,28 @@ class NetweaverInstance(object):
             conf_file (str): Path to the configuration file
             root_user (str): Root user name
             password (str): Root user password
+            cwd (str, opt): New value for SAPINST_CWD parameter
             exception (bool, opt): Raise and exception in case of error if True, return result
                 object otherwise
             remote_host (str, opt): Remote host where the command will be executed
         """
+        cwd = kwargs.get('cwd', None)
         raise_exception = kwargs.get('exception', True)
         remote_host = kwargs.get('remote_host', None)
+
+        if cwd:
+            # This operation must be done in order to avoid incorrect files usage
+            cls._remove_old_files(cwd, root_user, password, remote_host)
 
         cmd = '{software_path}/sapinst SAPINST_USE_HOSTNAME={virtual_host} '\
             'SAPINST_EXECUTE_PRODUCT_ID={product_id} '\
             'SAPINST_SKIP_SUCCESSFULLY_FINISHED_DIALOG=true SAPINST_START_GUISERVER=false '\
-            'SAPINST_INPUT_PARAMETERS_URL={conf_file}'.format(
+            'SAPINST_INPUT_PARAMETERS_URL={conf_file}{cwd}'.format(
                 software_path=software_path,
                 virtual_host=virtual_host,
                 product_id=product_id,
-                conf_file=conf_file)
+                conf_file=conf_file,
+                cwd=' SAPINST_CWD={}'.format(cwd) if cwd else '')
         result = shell.execute_cmd(cmd, root_user, password, remote_host)
         if result.returncode and raise_exception:
             raise NetweaverError('SAP Netweaver installation failed')
@@ -267,13 +287,14 @@ class NetweaverInstance(object):
             conf_file, 'nwUsers.sidadmPassword += +(.*)').group(1)
         ascs_pass = kwargs.get('ascs_password', ers_pass)
         remote_host = kwargs.get('remote_host', None)
+        cwd = kwargs.get('cwd', None)
 
         current_time = time.clock()
         current_timeout = current_time + timeout
         while current_time <= current_timeout:
             result = cls.install(
                 software_path, virtual_host, product_id, conf_file, root_user, password,
-                exception=False, remote_host=remote_host)
+                exception=False, remote_host=remote_host, cwd=cwd)
 
             if result.returncode == cls.SUCCESSFULLY_INSTALLED or \
                     cls._ascs_restart_needed(result):

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -112,7 +112,7 @@ class NetweaverInstance(object):
         Check if ASCS instance is installed
         """
         msg_server = shell.find_pattern(r'msg_server, MessageServer,.*', processes.output)
-        enserver = shell.find_pattern(r'enserver, EnqueueServer,', processes.output)
+        enserver = shell.find_pattern(r'enserver, EnqueueServer,.*', processes.output)
         return bool(msg_server and enserver)
 
     @staticmethod
@@ -120,8 +120,19 @@ class NetweaverInstance(object):
         """
         Check if ERS instance is installed
         """
-        msg_server = shell.find_pattern(r'enrepserver, EnqueueReplicator.*', processes.output)
-        return bool(msg_server)
+        enrepserver = shell.find_pattern(r'enrepserver, EnqueueReplicator,.*', processes.output)
+        return bool(enrepserver)
+
+    @staticmethod
+    def _is_app_server_installed(processes):
+        """
+        Check if an application server (PAS or AAS) instance is installed
+        """
+        disp = shell.find_pattern(r'disp\+work, Dispatcher,.*', processes.output)
+        igswd = shell.find_pattern(r'igswd_mt, IGS Watchdog,.*', processes.output)
+        gwrd = shell.find_pattern(r'gwrd, Gateway,.*', processes.output)
+        icman = shell.find_pattern(r'icman, ICM,.*', processes.output)
+        return bool(disp and igswd and gwrd and icman)
 
     def is_installed(self, sap_instance=None):
         """
@@ -144,6 +155,8 @@ class NetweaverInstance(object):
             return self._is_ascs_installed(processes)
         elif sap_instance == 'ers':
             return self._is_ers_installed(processes)
+        elif sap_instance in ['pas', 'aas']:
+            return self._is_app_server_installed(processes)
         else:
             raise ValueError('provided sap instance type is not valid: {}'.format(sap_instance))
 

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -155,7 +155,7 @@ class NetweaverInstance(object):
             return self._is_ascs_installed(processes)
         elif sap_instance == 'ers':
             return self._is_ers_installed(processes)
-        elif sap_instance in ['pas', 'aas']:
+        elif sap_instance in ['ci', 'di']:
             return self._is_app_server_installed(processes)
         else:
             raise ValueError('provided sap instance type is not valid: {}'.format(sap_instance))
@@ -289,7 +289,7 @@ class NetweaverInstance(object):
         remote_host = kwargs.get('remote_host', None)
         cwd = kwargs.get('cwd', None)
 
-        current_time = time.clock()
+        current_time = time.time()
         current_timeout = current_time + timeout
         while current_time <= current_timeout:
             result = cls.install(
@@ -302,7 +302,7 @@ class NetweaverInstance(object):
                 break
 
             time.sleep(interval)
-            current_time = time.clock()
+            current_time = time.time()
         else:
             raise NetweaverError(
                 'SAP Netweaver ERS installation failed after {} seconds'.format(timeout))

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -139,7 +139,7 @@ class NetweaverInstance(object):
         Check if SAP Netweaver is installed
 
         Args:
-            sap_instance (str): SAP instance type. Available options: ascs
+            sap_instance (str): SAP instance type. Available options: ascs, ers, ci, di
                 If None, if any NW installation is existing will be checked
 
         Returns:
@@ -148,17 +148,18 @@ class NetweaverInstance(object):
         processes = self.get_process_list(False)
         # TODO: Might be done using a dictionary to store the methods and keys
         if processes.returncode not in self.GETPROCESSLIST_SUCCESS_CODES:
-            return False
+            state = False
         elif not sap_instance:
-            return True
+            state = True
         elif sap_instance == 'ascs':
-            return self._is_ascs_installed(processes)
+            state = self._is_ascs_installed(processes)
         elif sap_instance == 'ers':
-            return self._is_ers_installed(processes)
+            state = self._is_ers_installed(processes)
         elif sap_instance in ['ci', 'di']:
-            return self._is_app_server_installed(processes)
+            state = self._is_app_server_installed(processes)
         else:
             raise ValueError('provided sap instance type is not valid: {}'.format(sap_instance))
+        return state
 
     @staticmethod
     def _remove_old_files(cwd, root_user, password, remote_host):
@@ -187,6 +188,8 @@ class NetweaverInstance(object):
             root_user (str): Root user name
             password (str): Root user password
             cwd (str, opt): New value for SAPINST_CWD parameter
+                CAUTION: All of the files stored in this path will be removed except the
+                start_dir.cd. This folder only will contain temporary files about the installation.
             exception (bool, opt): Raise and exception in case of error if True, return result
                 object otherwise
             remote_host (str, opt): Remote host where the command will be executed

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -397,9 +397,9 @@ class TestHana(unittest.TestCase):
         ])
 
 
-    @mock.patch('time.clock')
-    def test_register_basic(self, mock_clock):
-        mock_clock.return_value = 0
+    @mock.patch('time.time')
+    def test_register_basic(self, mock_time):
+        mock_time.return_value = 0
         self._hana._run_hana_command = mock.Mock()
         result_mock = mock.Mock(returncode=0)
         self._hana._run_hana_command.return_value = result_mock
@@ -409,9 +409,9 @@ class TestHana(unittest.TestCase):
             '--remoteInstance={} --replicationMode={} --operationMode={}'.format(
             'test', 'host', '01', 'sync', 'ops'), False)
 
-    @mock.patch('time.clock')
-    def test_register_copy_ssfs(self, mock_clock):
-        mock_clock.return_value = 0
+    @mock.patch('time.time')
+    def test_register_copy_ssfs(self, mock_time):
+        mock_time.return_value = 0
         self._hana._run_hana_command = mock.Mock()
         result_mock = mock.Mock(returncode=149)
         self._hana.copy_ssfs_files = mock.Mock()
@@ -429,10 +429,10 @@ class TestHana(unittest.TestCase):
         ])
         self._hana.copy_ssfs_files.assert_called_once_with('host', 'pass')
 
-    @mock.patch('time.clock')
+    @mock.patch('time.time')
     @mock.patch('time.sleep')
-    def test_register_loop(self, mock_sleep, mock_clock):
-        mock_clock.side_effect = [0, 1, 2, 3]
+    def test_register_loop(self, mock_sleep, mock_time):
+        mock_time.side_effect = [0, 1, 2, 3]
         self._hana._run_hana_command = mock.Mock()
         result_mock1 = mock.Mock(returncode=1)
         result_mock2 = mock.Mock(returncode=1)
@@ -458,10 +458,10 @@ class TestHana(unittest.TestCase):
         ])
         mock_sleep.assert_has_calls([mock.call(2), mock.call(2)])
 
-    @mock.patch('time.clock')
+    @mock.patch('time.time')
     @mock.patch('time.sleep')
-    def test_register_error(self, mock_sleep, mock_clock):
-        mock_clock.side_effect = [0, 1, 2, 3]
+    def test_register_error(self, mock_sleep, mock_time):
+        mock_time.side_effect = [0, 1, 2, 3]
         self._hana._run_hana_command = mock.Mock()
         result_mock1 = mock.Mock(returncode=1)
         result_mock2 = mock.Mock(returncode=1)

--- a/tests/netweaver_test.py
+++ b/tests/netweaver_test.py
@@ -162,7 +162,7 @@ class TestNetweaver(unittest.TestCase):
 
         mock_find_pattern.assert_has_calls([
             mock.call(r'msg_server, MessageServer,.*', 'output'),
-            mock.call(r'enserver, EnqueueServer,', 'output')
+            mock.call(r'enserver, EnqueueServer,.*', 'output')
         ])
 
         mock_find_pattern.reset_mock()
@@ -172,7 +172,7 @@ class TestNetweaver(unittest.TestCase):
 
         mock_find_pattern.assert_has_calls([
             mock.call(r'msg_server, MessageServer,.*', 'output'),
-            mock.call(r'enserver, EnqueueServer,', 'output')
+            mock.call(r'enserver, EnqueueServer,.*', 'output')
         ])
 
     @mock.patch('shaptools.shell.find_pattern')
@@ -184,7 +184,7 @@ class TestNetweaver(unittest.TestCase):
         self.assertTrue(self._netweaver._is_ers_installed(mock_process))
 
         mock_find_pattern.assert_called_once_with(
-            r'enrepserver, EnqueueReplicator.*', 'output')
+            r'enrepserver, EnqueueReplicator,.*', 'output')
 
         mock_find_pattern.reset_mock()
         mock_find_pattern.side_effect = ['']
@@ -192,7 +192,7 @@ class TestNetweaver(unittest.TestCase):
         self.assertFalse(self._netweaver._is_ers_installed(mock_process))
 
         mock_find_pattern.assert_called_once_with(
-            r'enrepserver, EnqueueReplicator.*', 'output')
+            r'enrepserver, EnqueueReplicator,.*', 'output')
 
     def test_is_installed(self):
 

--- a/tests/netweaver_test.py
+++ b/tests/netweaver_test.py
@@ -257,6 +257,22 @@ class TestNetweaver(unittest.TestCase):
             'SAPINST_INPUT_PARAMETERS_URL=/inifile.params'
         mock_execute_cmd.assert_called_once_with(cmd, 'root', 'pass', None)
 
+    @mock.patch('shaptools.netweaver.NetweaverInstance._remove_old_files')
+    @mock.patch('shaptools.shell.execute_cmd')
+    def test_install_cwd(self, mock_execute_cmd, mock_remove_old_files):
+
+        result = mock.Mock(returncode=0)
+        mock_execute_cmd.return_value = result
+
+        self._netweaver.install(
+            '/path', 'virtual', 'MYPRODUCT', '/inifile.params', 'root', 'pass', cwd='/tmp')
+        cmd = '/path/sapinst SAPINST_USE_HOSTNAME=virtual '\
+            'SAPINST_EXECUTE_PRODUCT_ID=MYPRODUCT '\
+            'SAPINST_SKIP_SUCCESSFULLY_FINISHED_DIALOG=true SAPINST_START_GUISERVER=false '\
+            'SAPINST_INPUT_PARAMETERS_URL=/inifile.params SAPINST_CWD=/tmp'
+        mock_remove_old_files.assert_called_once_with('/tmp', 'root', 'pass', None)
+        mock_execute_cmd.assert_called_once_with(cmd, 'root', 'pass', None)
+
     @mock.patch('shaptools.shell.execute_cmd')
     def test_install_error(self, mock_execute_cmd):
 
@@ -368,12 +384,12 @@ class TestNetweaver(unittest.TestCase):
 
         netweaver.NetweaverInstance.install_ers(
             'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-            ascs_password='ascs_pass', timeout=5, interval=1)
+            ascs_password='ascs_pass', timeout=5, interval=1, cwd='/tmp')
 
         mock_result.group.assert_called_once_with(1)
         mock_install.assert_called_once_with(
             'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-            exception=False, remote_host=None)
+            exception=False, remote_host=None, cwd='/tmp')
         mock_restart_needed.assert_called_once_with(mock_install_result)
         mock_restart.assert_called_once_with('conf_file', 'ers_pass', 'ascs_pass', None)
 
@@ -403,13 +419,13 @@ class TestNetweaver(unittest.TestCase):
         mock_install.assert_has_calls([
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None),
+                exception=False, remote_host=None, cwd=None),
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None),
+                exception=False, remote_host=None, cwd=None),
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None)
+                exception=False, remote_host=None, cwd=None)
         ])
         mock_restart_needed.assert_has_calls([
             mock.call(mock_install_result),
@@ -454,13 +470,13 @@ class TestNetweaver(unittest.TestCase):
         mock_install.assert_has_calls([
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None),
+                exception=False, remote_host=None, cwd=None),
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None),
+                exception=False, remote_host=None, cwd=None),
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None)
+                exception=False, remote_host=None, cwd=None)
         ])
         mock_restart_needed.assert_has_calls([
             mock.call(mock_install_result),
@@ -503,13 +519,13 @@ class TestNetweaver(unittest.TestCase):
         mock_install.assert_has_calls([
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None),
+                exception=False, remote_host=None, cwd=None),
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None),
+                exception=False, remote_host=None, cwd=None),
             mock.call(
                 'software', 'myhost', 'product', 'conf_file', 'user', 'pass',
-                exception=False, remote_host=None)
+                exception=False, remote_host=None, cwd=None)
         ])
         mock_restart_needed.assert_has_calls([
             mock.call(mock_install_result),

--- a/tests/netweaver_test.py
+++ b/tests/netweaver_test.py
@@ -364,20 +364,20 @@ class TestNetweaver(unittest.TestCase):
         mock_start.assert_called_once_with(
             host='ascs_hostname', inst='ascs_inst', user='ha1adm', password='ascs_pass')
 
-    @mock.patch('time.clock')
+    @mock.patch('time.time')
     @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
     @mock.patch('shaptools.netweaver.NetweaverInstance.install')
     @mock.patch('shaptools.netweaver.NetweaverInstance._ascs_restart_needed')
     @mock.patch('shaptools.netweaver.NetweaverInstance._restart_ascs')
     def test_install_ers_first_install(
             self, mock_restart, mock_restart_needed, mock_install,
-            mock_get_attribute, mock_clock):
+            mock_get_attribute, mock_time):
 
         mock_result = mock.Mock()
         mock_result.group.return_value = 'ers_pass'
         mock_get_attribute.return_value = mock_result
 
-        mock_clock.return_value = 1
+        mock_time.return_value = 1
         mock_install_result = mock.Mock(returncode=111)
         mock_install.return_value = mock_install_result
         mock_restart_needed.return_value = True
@@ -393,20 +393,20 @@ class TestNetweaver(unittest.TestCase):
         mock_restart_needed.assert_called_once_with(mock_install_result)
         mock_restart.assert_called_once_with('conf_file', 'ers_pass', 'ascs_pass', None)
 
-    @mock.patch('time.clock')
+    @mock.patch('time.time')
     @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
     @mock.patch('shaptools.netweaver.NetweaverInstance.install')
     @mock.patch('shaptools.netweaver.NetweaverInstance._ascs_restart_needed')
     @mock.patch('shaptools.netweaver.NetweaverInstance._restart_ascs')
     def test_install_ers_loop_install(
             self, mock_restart, mock_restart_needed, mock_install,
-            mock_get_attribute, mock_sleep, mock_clock):
+            mock_get_attribute, mock_sleep, mock_time):
 
         mock_result = mock.Mock()
         mock_result.group.return_value = 'ers_pass'
         mock_get_attribute.return_value = mock_result
 
-        mock_clock.side_effect = [1, 2, 3, 4, 5]
+        mock_time.side_effect = [1, 2, 3, 4, 5]
         mock_install_result = mock.Mock(returncode=111)
         mock_install.side_effect = [mock_install_result, mock_install_result, mock_install_result]
         mock_restart_needed.side_effect = [False, False, True]
@@ -433,7 +433,7 @@ class TestNetweaver(unittest.TestCase):
             mock.call(mock_install_result)
         ])
         mock_restart.assert_called_once_with('conf_file', 'ers_pass', 'ers_pass', None)
-        mock_clock.assert_has_calls([
+        mock_time.assert_has_calls([
             mock.call(),
             mock.call(),
             mock.call()
@@ -443,7 +443,7 @@ class TestNetweaver(unittest.TestCase):
             mock.call(1)
         ])
 
-    @mock.patch('time.clock')
+    @mock.patch('time.time')
     @mock.patch('time.sleep')
     @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
     @mock.patch('shaptools.netweaver.NetweaverInstance.install')
@@ -451,13 +451,13 @@ class TestNetweaver(unittest.TestCase):
     @mock.patch('shaptools.netweaver.NetweaverInstance._restart_ascs')
     def test_install_ers_loop_install(
             self, mock_restart, mock_restart_needed, mock_install,
-            mock_get_attribute, mock_sleep, mock_clock):
+            mock_get_attribute, mock_sleep, mock_time):
 
         mock_result = mock.Mock()
         mock_result.group.return_value = 'ers_pass'
         mock_get_attribute.return_value = mock_result
 
-        mock_clock.side_effect = [1, 2, 3, 4, 5]
+        mock_time.side_effect = [1, 2, 3, 4, 5]
         mock_install_result = mock.Mock(returncode=111)
         mock_install.side_effect = [mock_install_result, mock_install_result, mock_install_result]
         mock_restart_needed.side_effect = [False, False, True]
@@ -484,27 +484,27 @@ class TestNetweaver(unittest.TestCase):
             mock.call(mock_install_result)
         ])
         mock_restart.assert_called_once_with('conf_file', 'ers_pass', 'ers_pass', None)
-        self.assertEqual(mock_clock.call_count, 3)
+        self.assertEqual(mock_time.call_count, 3)
         self.assertEqual(mock_sleep.call_count, 2)
         mock_sleep.assert_has_calls([
             mock.call(1),
             mock.call(1)
         ])
 
-    @mock.patch('time.clock')
+    @mock.patch('time.time')
     @mock.patch('time.sleep')
     @mock.patch('shaptools.netweaver.NetweaverInstance.get_attribute_from_file')
     @mock.patch('shaptools.netweaver.NetweaverInstance.install')
     @mock.patch('shaptools.netweaver.NetweaverInstance._ascs_restart_needed')
     def test_install_ers_error_install(
             self, mock_restart_needed, mock_install,
-            mock_get_attribute, mock_sleep, mock_clock):
+            mock_get_attribute, mock_sleep, mock_time):
 
         mock_result = mock.Mock()
         mock_result.group.return_value = 'ers_pass'
         mock_get_attribute.return_value = mock_result
 
-        mock_clock.side_effect = [1, 2, 3, 5]
+        mock_time.side_effect = [1, 2, 3, 5]
         mock_install_result = mock.Mock(returncode=111)
         mock_install.side_effect = [mock_install_result, mock_install_result, mock_install_result]
         mock_restart_needed.side_effect = [False, False, False]
@@ -532,7 +532,7 @@ class TestNetweaver(unittest.TestCase):
             mock.call(mock_install_result),
             mock.call(mock_install_result)
         ])
-        self.assertEqual(mock_clock.call_count, 4)
+        self.assertEqual(mock_time.call_count, 4)
         self.assertEqual(mock_sleep.call_count, 3)
         mock_sleep.assert_has_calls([
             mock.call(1),


### PR DESCRIPTION
Add new required methods to install Netweaver DB, PAS and AAS instances.

The main change is to add the `cwd` parameter option to the install method, in order to give the option to use `SAPINST_CWD`.
Here some background:
https://answers.sap.com/questions/9530689/issue-in-sap-netweaver-unattended-installation.html