### PR TITLE
Update install fn to input passwords from xml file

### DIFF
--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -186,7 +186,9 @@ class HanaInstance(object):
         return conf_file
 
     @classmethod
-    def install(cls, software_path, conf_file, root_user, password, remote_host=None):
+    def install(
+            cls, software_path, conf_file, root_user, password,
+            hdb_pwd_file=None, remote_host=None):
         """
         Install SAP HANA platform providing a configuration file
 
@@ -195,14 +197,20 @@ class HanaInstance(object):
             conf_file (str): Path to the configuration file
             root_user (str): Root user name
             password (str): Root user password
+            hdb_pwd_file (str, opt): Path to the XML password file
             remote_host (str, opt): Remote host where the command will be executed
         """
         # TODO: mount partition if needed
         # TODO: do some integrity check stuff
         platform_folder = cls.get_platform()
         executable = cls.INSTALL_EXEC.format(software_path=software_path, platform=platform_folder)
-        cmd = '{executable} -b --configfile={conf_file}'.format(
-            executable=executable, conf_file=conf_file)
+        if hdb_pwd_file:
+            cmd = ('cat {hdb_pwd_file} | {executable} -b '
+                   '--read_password_from_stdin=xml --configfile={conf_file}'.format(
+                       hdb_pwd_file=hdb_pwd_file, executable=executable, conf_file=conf_file))
+        else:
+            cmd = '{executable} -b --configfile={conf_file}'.format(
+                executable=executable, conf_file=conf_file)
         result = shell.execute_cmd(cmd, root_user, password, remote_host)
         if result.returncode:
             raise HanaError('SAP HANA installation failed')

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -205,9 +205,9 @@ class HanaInstance(object):
         platform_folder = cls.get_platform()
         executable = cls.INSTALL_EXEC.format(software_path=software_path, platform=platform_folder)
         if hdb_pwd_file:
-            cmd = ('cat {hdb_pwd_file} | {executable} -b '
-                   '--read_password_from_stdin=xml --configfile={conf_file}'.format(
-                       hdb_pwd_file=hdb_pwd_file, executable=executable, conf_file=conf_file))
+            cmd = 'cat {hdb_pwd_file} | {executable} -b '\
+                '--read_password_from_stdin=xml --configfile={conf_file}'.format(
+                    hdb_pwd_file=hdb_pwd_file, executable=executable, conf_file=conf_file)
         else:
             cmd = '{executable} -b --configfile={conf_file}'.format(
                 executable=executable, conf_file=conf_file)

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -19,6 +19,7 @@ import fileinput
 import re
 import time
 import platform
+import os
 
 from shaptools import shell
 
@@ -34,6 +35,10 @@ class HanaError(Exception):
     Error during HANA command execution
     """
 
+class FileDoesNotExist(Exception):
+    """
+    Error when the specified files does not exist
+    """
 
 # System replication states
 # Random value used
@@ -202,6 +207,12 @@ class HanaInstance(object):
         """
         # TODO: mount partition if needed
         # TODO: do some integrity check stuff
+
+        if not os.path.isfile(conf_file):
+            raise FileDoesNotExist('The configuration file does not exist')
+        if hdb_pwd_file is not None and not os.path.isfile(hdb_pwd_file):
+            raise FileDoesNotExist('The XML password file does not exist')
+
         platform_folder = cls.get_platform()
         executable = cls.INSTALL_EXEC.format(software_path=software_path, platform=platform_folder)
         if hdb_pwd_file:

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -35,7 +35,7 @@ class HanaError(Exception):
     Error during HANA command execution
     """
 
-class FileDoesNotExist(Exception):
+class FileDoesNotExistError(Exception):
     """
     Error when the specified files does not exist
     """
@@ -209,9 +209,9 @@ class HanaInstance(object):
         # TODO: do some integrity check stuff
 
         if not os.path.isfile(conf_file):
-            raise FileDoesNotExist('The configuration file \'{}\' does not exist'.format(conf_file))
+            raise FileDoesNotExistError('The configuration file \'{}\' does not exist'.format(conf_file))
         if hdb_pwd_file is not None and not os.path.isfile(hdb_pwd_file):
-            raise FileDoesNotExist('The XML password file \'{}\' does not exist'.format(hdb_pwd_file))
+            raise FileDoesNotExistError('The XML password file \'{}\' does not exist'.format(hdb_pwd_file))
 
         platform_folder = cls.get_platform()
         executable = cls.INSTALL_EXEC.format(software_path=software_path, platform=platform_folder)

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -209,9 +209,9 @@ class HanaInstance(object):
         # TODO: do some integrity check stuff
 
         if not os.path.isfile(conf_file):
-            raise FileDoesNotExist('The configuration file does not exist')
+            raise FileDoesNotExist('The configuration file \'{}\' does not exist'.format(conf_file))
         if hdb_pwd_file is not None and not os.path.isfile(hdb_pwd_file):
-            raise FileDoesNotExist('The XML password file does not exist')
+            raise FileDoesNotExist('The XML password file \'{}\' does not exist'.format(hdb_pwd_file))
 
         platform_folder = cls.get_platform()
         executable = cls.INSTALL_EXEC.format(software_path=software_path, platform=platform_folder)

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -286,7 +286,7 @@ class TestHana(unittest.TestCase):
     def test_install_FileDoesNotExistError(self, mock_conf_file):
         mock_conf_file.return_value = False
         
-        with self.assertRaises(hana.FileDoesNotExist) as err:
+        with self.assertRaises(hana.FileDoesNotExistError) as err:
             hana.HanaInstance.install(
                 'software_path', 'conf_file.conf', 'root', 'pass')
 
@@ -297,7 +297,7 @@ class TestHana(unittest.TestCase):
     def test_install_xml_FileDoesNotExistError(self, mock_passwords_xml):
         mock_passwords_xml.side_effect = [True, False]
 
-        with self.assertRaises(hana.FileDoesNotExist) as err:
+        with self.assertRaises(hana.FileDoesNotExistError) as err:
             hana.HanaInstance.install(
                 'software_path', 'conf_file.conf', 'root', 'pass',
                 hdb_pwd_file='hdb_password.xml')

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -221,117 +221,89 @@ class TestHana(unittest.TestCase):
 
     @mock.patch('shaptools.hana.HanaInstance.get_platform')
     @mock.patch('shaptools.shell.execute_cmd')
-    def test_install(self, mock_execute, mock_get_platform):
+    @mock.patch('os.path.isfile')
+    def test_install(self, mock_conf_file, mock_execute, mock_get_platform):
         proc_mock = mock.Mock()
         proc_mock.returncode = 0
+        mock_conf_file.side_effect = [True, True]
         mock_execute.return_value = proc_mock
         mock_get_platform.return_value = 'my_arch'
-        pwd = os.path.dirname(os.path.abspath(__file__))
 
         hana.HanaInstance.install(
-            'software_path', pwd+'/support/original.conf', 'root', 'pass')
-
-        mock_execute.assert_called_once_with(
-            'software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '\
-            '-b --configfile={conf_file}'.format(
-                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
-        mock_get_platform.assert_called_once_with()
-
-    @mock.patch('shaptools.hana.HanaInstance.get_platform')
-    @mock.patch('shaptools.shell.execute_cmd')
-    def test_install_xml(self, mock_execute, mock_get_platform):
-        proc_mock = mock.Mock()
-        proc_mock.returncode = 0
-        mock_execute.return_value = proc_mock
-        mock_get_platform.return_value = 'my_arch'
-        pwd = os.path.dirname(os.path.abspath(__file__))
-
-        hana.HanaInstance.install(
-            'software_path', pwd+'/support/original.conf', 'root', 'pass', 
-            hdb_pwd_file=pwd+'/support/hdb_passwords.xml')
-
-        mock_execute.assert_called_once_with(
-            'cat {hdb_pwd_file} | software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '\
-            '-b --read_password_from_stdin=xml --configfile={conf_file}'.format(
-                hdb_pwd_file=pwd+'/support/hdb_passwords.xml', 
-                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
-        mock_get_platform.assert_called_once_with()
-
-    @mock.patch('shaptools.hana.HanaInstance.get_platform')
-    @mock.patch('shaptools.shell.execute_cmd')
-    def test_install_error(self, mock_execute, mock_get_platform):
-        proc_mock = mock.Mock()
-        proc_mock.returncode = 1
-        mock_execute.return_value = proc_mock
-        mock_get_platform.return_value = 'my_arch'
-        pwd = os.path.dirname(os.path.abspath(__file__))
-
-        with self.assertRaises(hana.HanaError) as err:
-            hana.HanaInstance.install(
-                'software_path', pwd+'/support/original.conf', 'root', 'pass')
+            'software_path', 'conf_file.conf', 'root', 'pass')
 
         mock_execute.assert_called_once_with(
             'software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '
             '-b --configfile={conf_file}'.format(
-                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
+                conf_file='conf_file.conf'), 'root', 'pass', None)
+        mock_get_platform.assert_called_once_with()
+
+    @mock.patch('shaptools.hana.HanaInstance.get_platform')
+    @mock.patch('shaptools.shell.execute_cmd')
+    @mock.patch('os.path.isfile')
+    def test_install_xml(self, mock_conf_file, mock_execute, mock_get_platform):
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 0
+        mock_conf_file.side_effect = [True, True]
+        mock_execute.return_value = proc_mock
+        mock_get_platform.return_value = 'my_arch'
+
+        hana.HanaInstance.install(
+            'software_path', 'conf_file.conf', 'root', 'pass', 
+            hdb_pwd_file='hdb_passwords.xml')
+
+        mock_execute.assert_called_once_with(
+            'cat {hdb_pwd_file} | software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '\
+            '-b --read_password_from_stdin=xml --configfile={conf_file}'.format(
+                hdb_pwd_file='hdb_passwords.xml', 
+                conf_file='conf_file.conf'), 'root', 'pass', None)
+        mock_get_platform.assert_called_once_with()
+
+    @mock.patch('shaptools.hana.HanaInstance.get_platform')
+    @mock.patch('shaptools.shell.execute_cmd')
+    @mock.patch('os.path.isfile')
+    def test_install_error(self, mock_conf_file, mock_execute, mock_get_platform):
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 1
+        mock_conf_file.side_effect = [True, True]
+        mock_execute.return_value = proc_mock
+        mock_get_platform.return_value = 'my_arch'
+
+        with self.assertRaises(hana.HanaError) as err:
+            hana.HanaInstance.install(
+                'software_path', 'conf_file.conf', 'root', 'pass')
+
+        mock_execute.assert_called_once_with(
+            'software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '
+            '-b --configfile={conf_file}'.format(
+                conf_file='conf_file.conf'), 'root', 'pass', None)
         mock_get_platform.assert_called_once_with()
 
         self.assertTrue(
             'SAP HANA installation failed' in str(err.exception))
 
-    @mock.patch('shaptools.hana.HanaInstance.get_platform')
-    @mock.patch('shaptools.shell.execute_cmd')
-    def test_install_xml_error(self, mock_execute, mock_get_platform):
-        proc_mock = mock.Mock()
-        proc_mock.returncode = 1
-        mock_execute.return_value = proc_mock
-        mock_get_platform.return_value = 'my_arch'
-        pwd = os.path.dirname(os.path.abspath(__file__))
-
-        with self.assertRaises(hana.HanaError) as err:
+    @mock.patch('os.path.isfile')
+    def test_install_FileDoesNotExistError(self, mock_conf_file):
+        mock_conf_file.return_value = False
+        
+        with self.assertRaises(hana.FileDoesNotExist) as err:
             hana.HanaInstance.install(
-                'software_path', pwd+'/support/original.conf', 'root', 'pass',
-                hdb_pwd_file=pwd+'/support/hdb_passwords.xml')
+                'software_path', 'conf_file.conf', 'root', 'pass')
 
-        mock_execute.assert_called_once_with(
-            'cat {hdb_pwd_file} | software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '\
-            '-b --read_password_from_stdin=xml --configfile={conf_file}'.format(
-                hdb_pwd_file=pwd+'/support/hdb_passwords.xml', 
-                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
-        mock_get_platform.assert_called_once_with()
+        self.assertTrue(
+            'The configuration file \'{}\' does not exist'.format('conf_file.conf') in str(err.exception))
 
-    @mock.patch('shaptools.hana.HanaInstance.get_platform')
-    @mock.patch('shaptools.shell.execute_cmd')
-    def test_install_FileDoesNotExist(self, mock_execute, mock_get_platform):
-        proc_mock = mock.Mock()
-        proc_mock.returncode = 1
-        mock_execute.return_value = proc_mock
-        mock_get_platform.return_value = 'my_arch'
-        pwd = os.path.dirname(os.path.abspath(__file__))
+    @mock.patch('os.path.isfile')
+    def test_install_xml_FileDoesNotExistError(self, mock_passwords_xml):
+        mock_passwords_xml.side_effect = [True, False]
 
         with self.assertRaises(hana.FileDoesNotExist) as err:
             hana.HanaInstance.install(
-                'software_path', pwd+'/support/originals.conf', 'root', 'pass')
+                'software_path', 'conf_file.conf', 'root', 'pass',
+                hdb_pwd_file='hdb_password.xml')
 
         self.assertTrue(
-            'The configuration file does not exist' in str(err.exception))
-
-    @mock.patch('shaptools.hana.HanaInstance.get_platform')
-    @mock.patch('shaptools.shell.execute_cmd')
-    def test_install_xml_FileDoesNotExist(self, mock_execute, mock_get_platform):
-        proc_mock = mock.Mock()
-        proc_mock.returncode = 1
-        mock_execute.return_value = proc_mock
-        mock_get_platform.return_value = 'my_arch'
-        pwd = os.path.dirname(os.path.abspath(__file__))
-
-        with self.assertRaises(hana.FileDoesNotExist) as err:
-            hana.HanaInstance.install(
-                'software_path', pwd+'/support/original.conf', 'root', 'pass',
-                hdb_pwd_file=pwd+'/support/hdb_password.xml')
-
-        self.assertTrue(
-            'The XML password file does not exist' in str(err.exception))
+            'The XML password file \'{}\' does not exist'.format('hdb_password.xml') in str(err.exception))
 
     @mock.patch('shaptools.shell.execute_cmd')
     def test_uninstall(self, mock_execute):

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -226,14 +226,15 @@ class TestHana(unittest.TestCase):
         proc_mock.returncode = 0
         mock_execute.return_value = proc_mock
         mock_get_platform.return_value = 'my_arch'
+        pwd = os.path.dirname(os.path.abspath(__file__))
 
         hana.HanaInstance.install(
-            'software_path', 'conf_file.conf', 'root', 'pass')
+            'software_path', pwd+'/support/original.conf', 'root', 'pass')
 
         mock_execute.assert_called_once_with(
-            'software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '
+            'software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '\
             '-b --configfile={conf_file}'.format(
-                conf_file='conf_file.conf'), 'root', 'pass', None)
+                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
         mock_get_platform.assert_called_once_with()
 
     @mock.patch('shaptools.hana.HanaInstance.get_platform')
@@ -243,14 +244,17 @@ class TestHana(unittest.TestCase):
         proc_mock.returncode = 0
         mock_execute.return_value = proc_mock
         mock_get_platform.return_value = 'my_arch'
+        pwd = os.path.dirname(os.path.abspath(__file__))
 
         hana.HanaInstance.install(
-            'software_path', 'conf_file.conf', 'root', 'pass', hdb_pwd_file='hdb_passwords.xml')
+            'software_path', pwd+'/support/original.conf', 'root', 'pass', 
+            hdb_pwd_file=pwd+'/support/hdb_passwords.xml')
 
         mock_execute.assert_called_once_with(
-            'cat {hdb_pwd_file} | software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '
+            'cat {hdb_pwd_file} | software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '\
             '-b --read_password_from_stdin=xml --configfile={conf_file}'.format(
-                hdb_pwd_file='hdb_passwords.xml', conf_file='conf_file.conf'), 'root', 'pass', None)
+                hdb_pwd_file=pwd+'/support/hdb_passwords.xml', 
+                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
         mock_get_platform.assert_called_once_with()
 
     @mock.patch('shaptools.hana.HanaInstance.get_platform')
@@ -260,15 +264,16 @@ class TestHana(unittest.TestCase):
         proc_mock.returncode = 1
         mock_execute.return_value = proc_mock
         mock_get_platform.return_value = 'my_arch'
+        pwd = os.path.dirname(os.path.abspath(__file__))
 
         with self.assertRaises(hana.HanaError) as err:
             hana.HanaInstance.install(
-                'software_path', 'conf_file.conf', 'root', 'pass')
+                'software_path', pwd+'/support/original.conf', 'root', 'pass')
 
         mock_execute.assert_called_once_with(
             'software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '
             '-b --configfile={conf_file}'.format(
-                conf_file='conf_file.conf'), 'root', 'pass', None)
+                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
         mock_get_platform.assert_called_once_with()
 
         self.assertTrue(
@@ -281,16 +286,52 @@ class TestHana(unittest.TestCase):
         proc_mock.returncode = 1
         mock_execute.return_value = proc_mock
         mock_get_platform.return_value = 'my_arch'
+        pwd = os.path.dirname(os.path.abspath(__file__))
 
         with self.assertRaises(hana.HanaError) as err:
             hana.HanaInstance.install(
-                'software_path', 'conf_file.conf', 'root', 'pass', hdb_pwd_file='hdb_passwords.xml')
+                'software_path', pwd+'/support/original.conf', 'root', 'pass',
+                hdb_pwd_file=pwd+'/support/hdb_passwords.xml')
 
         mock_execute.assert_called_once_with(
-            'cat {hdb_pwd_file} | software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '
+            'cat {hdb_pwd_file} | software_path/DATA_UNITS/HDB_LCM_LINUX_my_arch/hdblcm '\
             '-b --read_password_from_stdin=xml --configfile={conf_file}'.format(
-                hdb_pwd_file='hdb_passwords.xml', conf_file='conf_file.conf'), 'root', 'pass', None)
+                hdb_pwd_file=pwd+'/support/hdb_passwords.xml', 
+                conf_file=pwd+'/support/original.conf'), 'root', 'pass', None)
         mock_get_platform.assert_called_once_with()
+
+    @mock.patch('shaptools.hana.HanaInstance.get_platform')
+    @mock.patch('shaptools.shell.execute_cmd')
+    def test_install_FileDoesNotExist(self, mock_execute, mock_get_platform):
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 1
+        mock_execute.return_value = proc_mock
+        mock_get_platform.return_value = 'my_arch'
+        pwd = os.path.dirname(os.path.abspath(__file__))
+
+        with self.assertRaises(hana.FileDoesNotExist) as err:
+            hana.HanaInstance.install(
+                'software_path', pwd+'/support/originals.conf', 'root', 'pass')
+
+        self.assertTrue(
+            'The configuration file does not exist' in str(err.exception))
+
+    @mock.patch('shaptools.hana.HanaInstance.get_platform')
+    @mock.patch('shaptools.shell.execute_cmd')
+    def test_install_xml_FileDoesNotExist(self, mock_execute, mock_get_platform):
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 1
+        mock_execute.return_value = proc_mock
+        mock_get_platform.return_value = 'my_arch'
+        pwd = os.path.dirname(os.path.abspath(__file__))
+
+        with self.assertRaises(hana.FileDoesNotExist) as err:
+            hana.HanaInstance.install(
+                'software_path', pwd+'/support/original.conf', 'root', 'pass',
+                hdb_pwd_file=pwd+'/support/hdb_password.xml')
+
+        self.assertTrue(
+            'The XML password file does not exist' in str(err.exception))
 
     @mock.patch('shaptools.shell.execute_cmd')
     def test_uninstall(self, mock_execute):

--- a/tests/support/hdb_passwords.xml
+++ b/tests/support/hdb_passwords.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<Passwords> 
+<password><![CDATA[****]]></password>
+<sapadm_password><![CDATA[****]]></sapadm_password> 
+<system_user_password><![CDATA[****]]></system_user_password>
+<root_password><![CDATA[****]]></root_password> 
+</Passwords>

--- a/tests/support/hdb_passwords.xml
+++ b/tests/support/hdb_passwords.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?> 
-<Passwords> 
-<password><![CDATA[****]]></password>
-<sapadm_password><![CDATA[****]]></sapadm_password> 
-<system_user_password><![CDATA[****]]></system_user_password>
-<root_password><![CDATA[****]]></root_password> 
-</Passwords>


### PR DESCRIPTION
Update the install functionality to input HANA passwords from an XML file.
This can be used in combination with the HANA configuration file.

Details about XML file and updated commands:
https://help.sap.com/viewer/2c1988d620e04368aa4103bf26f17727/2.0.01/en-US/1dbba6ac03054d7eb07c819aae47d095.html#7087da9be88f4ed09fee09f1f70f3a05.html