### PR TITLE
Add function, UT to update HANA XML passwords file

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan  2 21:59:30 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Create package version 0.3.5
+- Add function to install HANA with XML passwords file
+- Add functionality to update XML passwords file
+
+-------------------------------------------------------------------
 Thu Dec  5 10:48:53 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Create package version 0.3.4

--- a/python-shaptools.spec
+++ b/python-shaptools.spec
@@ -22,7 +22,7 @@
 
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-shaptools
-Version:        0.3.4
+Version:        0.3.5
 Release:        0
 Summary:        Python tools to interact with SAP HANA utilities
 License:        Apache-2.0

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -167,6 +167,28 @@ class HanaInstance(object):
         return conf_file
 
     @classmethod
+    def update_hdb_pwd_file(cls, hdb_pwd_file, **kwargs):
+        """
+        Update SAP HANA XML passwords
+
+        Args:
+            hdb_pwd_file (str): Path to the XML passwords file
+            kwargs (opt): Dictionary with the values to be updated.
+                Use the exact name of the XML file for the key
+
+        kwargs can be used in the next two modes:
+            update_hdb_pwd_file(hdb_pwd_file, master_password='Test123', sapadm_password='pas11')
+            update_hdb_pwd_file(hdb_pwd_file, **{'master_password': 'Test123', 'sapadm_password': 'pas11'})
+        """
+        for key, value in kwargs.items():
+            pattern = '<{key}>.*'.format(key=key)
+            new_entry = '<{key}><![CDATA[{value}]]></{key}>'.format(key=key, value=value)
+            for line in fileinput.input(hdb_pwd_file, inplace=1):
+                line = re.sub(pattern, new_entry, line)
+                print(line, end='')
+        return hdb_pwd_file
+
+    @classmethod
     def create_conf_file(
             cls, software_path, conf_file, root_user, root_password, remote_host=None):
         """

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -184,7 +184,7 @@ class TestHana(unittest.TestCase):
         shutil.copyfile(pwd+'/support/original.conf.xml', '/tmp/test.conf.xml')
         hdb_pwd_file = hana.HanaInstance.update_hdb_pwd_file(
             '/tmp/test.conf.xml', master_password='Master1234', 
-            sapadm_password = 'Adm1234', system_user_password='Qwerty1234')
+            sapadm_password='Adm1234', system_user_password='Qwerty1234')
         self.assertTrue(filecmp.cmp(pwd+'/support/modified.conf.xml', hdb_pwd_file))
 
     @mock.patch('shaptools.hana.HanaInstance.get_platform')

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -179,6 +179,14 @@ class TestHana(unittest.TestCase):
             **{'sid': 'PRD', 'password': 'Qwerty1234', 'system_user_password': 'Qwerty1234'})
         self.assertTrue(filecmp.cmp(pwd+'/support/modified.conf', conf_file))
 
+    def test_update_hdb_pwd_file(self):
+        pwd = os.path.dirname(os.path.abspath(__file__))
+        shutil.copyfile(pwd+'/support/original.conf.xml', '/tmp/test.conf.xml')
+        hdb_pwd_file = hana.HanaInstance.update_hdb_pwd_file(
+            '/tmp/test.conf.xml', master_password='Master1234', 
+            sapadm_password = 'Adm1234', system_user_password='Qwerty1234')
+        self.assertTrue(filecmp.cmp(pwd+'/support/modified.conf.xml', hdb_pwd_file))
+
     @mock.patch('shaptools.hana.HanaInstance.get_platform')
     @mock.patch('shaptools.shell.execute_cmd')
     def test_create_conf_file(self, mock_execute, mock_get_platform):

--- a/tests/support/modified.conf.xml
+++ b/tests/support/modified.conf.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Replace the 3 asterisks with the password -->
+<Passwords>
+    <root_password><![CDATA[***]]></root_password>
+    <sapadm_password><![CDATA[Adm1234]]></sapadm_password>
+    <master_password><![CDATA[Master1234]]></master_password>
+    <sapadm_password><![CDATA[Adm1234]]></sapadm_password>
+    <password><![CDATA[***]]></password>
+    <system_user_password><![CDATA[Qwerty1234]]></system_user_password>
+    <lss_user_password><![CDATA[***]]></lss_user_password>
+    <lss_backup_password><![CDATA[***]]></lss_backup_password>
+    <streaming_cluster_manager_password><![CDATA[***]]></streaming_cluster_manager_password>
+    <ase_user_password><![CDATA[***]]></ase_user_password>
+    <org_manager_password><![CDATA[***]]></org_manager_password>
+</Passwords>

--- a/tests/support/original.conf.xml
+++ b/tests/support/original.conf.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Replace the 3 asterisks with the password -->
+<Passwords>
+    <root_password><![CDATA[***]]></root_password>
+    <sapadm_password><![CDATA[***]]></sapadm_password>
+    <master_password><![CDATA[***]]></master_password>
+    <sapadm_password><![CDATA[***]]></sapadm_password>
+    <password><![CDATA[***]]></password>
+    <system_user_password><![CDATA[***]]></system_user_password>
+    <lss_user_password><![CDATA[***]]></lss_user_password>
+    <lss_backup_password><![CDATA[***]]></lss_backup_password>
+    <streaming_cluster_manager_password><![CDATA[***]]></streaming_cluster_manager_password>
+    <ase_user_password><![CDATA[***]]></ase_user_password>
+    <org_manager_password><![CDATA[***]]></org_manager_password>
+</Passwords>


### PR DESCRIPTION
Adding this functionality to update the HANA XML password file, This file is used to store the HANA users passwords, and it gets generated as template (during create_conf_file) along with the HANA config file. 

Goal is use this functionality to store passwords in XML, instead of fetching passwords from pillar files. Ultimately, to utilize this function, similar functionality needs to be added to salt-shaptools, and some modification in the saphanabootstrap formula.

I am using the simple regex here. There exist some python libraries to modify XML, I tried the `ElementTree` library, but it would not consider the `CDATA` XML elements when parsing/outputing. Maybe there are better options to update the XML files.

Todo: update spec/change file