### PR TITLE
Feature/update get platform

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 19 15:31:22 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Create version 0.3.6
+- Change the get_platform method to include the system OS type 
+
+-------------------------------------------------------------------
 Thu Jan  2 21:59:30 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Create package version 0.3.5
@@ -9,7 +15,7 @@ Thu Jan  2 21:59:30 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 Thu Dec  5 10:48:53 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Create package version 0.3.4
-- Fix ascs restart conditions in ers installation 
+- Fix ascs restart conditions in ers installation
 
 -------------------------------------------------------------------
 Thu Nov  7 00:36:08 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
@@ -21,7 +27,7 @@ Thu Nov  7 00:36:08 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
 Tue Oct 22 02:41:35 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Create package version 0.3.2
-- Add isconnected and reconnect methods 
+- Add isconnected and reconnect methods
 
 -------------------------------------------------------------------
 Wed Aug  7 12:50:36 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
@@ -29,7 +35,7 @@ Wed Aug  7 12:50:36 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 - Add the required code to install SAP Netweaver instances
   * Wrap sapcontrol command usage
   * Install and uninstall SAP instances
-  * Check current installation status 
+  * Check current installation status
 
 -------------------------------------------------------------------
 Tue Jul 23 11:04:25 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>

--- a/python-shaptools.spec
+++ b/python-shaptools.spec
@@ -22,7 +22,7 @@
 
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-shaptools
-Version:        0.3.5
+Version:        0.3.6
 Release:        0
 Summary:        Python tools to interact with SAP HANA utilities
 License:        Apache-2.0

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -73,10 +73,11 @@ class HanaInstance(object):
     """
 
     PATH = '/usr/sap/{sid}/HDB{inst}/'
-    INSTALL_EXEC = '{software_path}/DATA_UNITS/HDB_LCM_LINUX_{platform}/hdblcm'
+    INSTALL_EXEC = '{software_path}/DATA_UNITS/HDB_LCM_{platform}/hdblcm'
     SUPPORTED_PLATFORMS = [
         'x86_64', 'ppc64le'
     ]
+    SUPPORTED_SYSTEMS = ['Linux']
     # SID is usualy written uppercased, but the OS user is always created lower case.
     HANAUSER = '{sid}adm'.lower()
     SYNCMODES = ['sync', 'syncmem', 'async']
@@ -106,7 +107,13 @@ class HanaInstance(object):
         logger.info('current platform is %s', current_platform)
         if current_platform not in cls.SUPPORTED_PLATFORMS:
             raise ValueError('not supported platform: {}'.format(current_platform))
-        return current_platform.upper()
+
+        current_system = platform.system()
+        logger.info('current system is %s', current_system)
+        if current_system not in cls.SUPPORTED_SYSTEMS:
+            raise ValueError('not supported system: {}'.format(current_system))
+
+        return '{}_{}'.format(current_system.upper(), current_platform.upper())
 
     def _run_hana_command(self, cmd, exception=True):
         """


### PR DESCRIPTION
As the SAP components name follow the syntax `{OS}_{ARCH}`, I have changed this method to make it simple.
The method will be used in the coming PRs in `salt-shaptools`.

Anyway, eventually, we might change `INSTALL_EXEC` usage and manage the path in other layer, salt-shaptools or in the formulas, as if the folder is extracted from a SAR file the file path is different.