### PR TITLE
Feature/hana install autodetection

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 24 11:29:14 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Create version 0.3.7
+- Improve hana installation software detection to allow more use
+  cases 
+
+-------------------------------------------------------------------
 Thu Mar 19 15:31:22 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Create version 0.3.6

--- a/python-shaptools.spec
+++ b/python-shaptools.spec
@@ -22,7 +22,7 @@
 
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-shaptools
-Version:        0.3.6
+Version:        0.3.7
 Release:        0
 Summary:        Python tools to interact with SAP HANA utilities
 License:        Apache-2.0

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -79,7 +79,7 @@ class HanaInstance(object):
 
     PATH = '/usr/sap/{sid}/HDB{inst}/'
     INSTALL_EXEC = 'hdblcm'
-    HANA_PLATFORM = '^HDB:HANA:.*:{platform}:SAP HANA PLATFORM EDITION.*'
+    HANA_PLATFORM = '^HDB:HANA:.*:{platform}:.*'
     SUPPORTED_PLATFORMS = [
         'x86_64', 'ppc64le'
     ]

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -130,9 +130,12 @@ class HanaInstance(object):
             software_path (str): Path of a folder where the HANA installation software is
             available
         """
+        logger = logging.getLogger('__name__')
         # hdbclm in the provider folder
-        if os.path.exists(os.path.join(software_path, cls.INSTALL_EXEC)):
-            return os.path.join(software_path, cls.INSTALL_EXEC)
+        hdblcm_path = os.path.join(software_path, cls.INSTALL_EXEC)
+        if os.path.exists(hdblcm_path):
+            logger.info('HANA installer found: %s', hdblcm_path)
+            return hdblcm_path
 
         # HANA platform folder
         label_file = os.path.join(software_path, 'LABEL.ASC')
@@ -148,13 +151,16 @@ class HanaInstance(object):
                         software_path, 'DATA_UNITS',
                         'HDB_SERVER_{}'.format(hana_platform), cls.INSTALL_EXEC)
                     if os.path.exists(hdblcm_path):
+                        logger.info('HANA installer found: %s', hdblcm_path)
                         return hdblcm_path
                     elif os.path.exists(hdbserver_path):
+                        logger.info('HANA installer found: %s', hdbserver_path)
                         return hdbserver_path
 
         # HANA server SAR patch
         hana_server_path = os.path.join(software_path, 'SAP_HANA_DATABASE', cls.INSTALL_EXEC)
         if os.path.exists(hana_server_path):
+            logger.info('HANA installer found: %s', hana_server_path)
             return hana_server_path
 
         raise HanaSoftwareNotFoundError('HANA installer not found in {}'.format(software_path))

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -40,6 +40,11 @@ class FileDoesNotExistError(Exception):
     Error when the specified files does not exist
     """
 
+class HanaSoftwareNotFoundError(HanaError):
+    """
+    HANA installation software not found
+    """
+
 # System replication states
 # Random value used
 SR_STATES = {
@@ -73,7 +78,8 @@ class HanaInstance(object):
     """
 
     PATH = '/usr/sap/{sid}/HDB{inst}/'
-    INSTALL_EXEC = '{software_path}/DATA_UNITS/HDB_LCM_{platform}/hdblcm'
+    INSTALL_EXEC = 'hdblcm'
+    HANA_PLATFORM = '^HDB:HANA:.*:{platform}:SAP HANA PLATFORM EDITION.*'
     SUPPORTED_PLATFORMS = [
         'x86_64', 'ppc64le'
     ]
@@ -114,6 +120,44 @@ class HanaInstance(object):
             raise ValueError('not supported system: {}'.format(current_system))
 
         return '{}_{}'.format(current_system.upper(), current_platform.upper())
+
+    @classmethod
+    def find_hana_hdblcm(cls, software_path):
+        """
+        Find a HANA installation executable in a folder (and subfolders)
+
+        Args:
+            software_path (str): Path of a folder where the HANA installation software is
+            available
+        """
+        # hdbclm in the provider folder
+        if os.path.exists(os.path.join(software_path, cls.INSTALL_EXEC)):
+            return os.path.join(software_path, cls.INSTALL_EXEC)
+
+        # HANA platform folder
+        label_file = os.path.join(software_path, 'LABEL.ASC')
+        if os.path.exists(label_file):
+            with open(label_file) as file_ptr:
+                hana_platform = cls.get_platform()
+                hana_pattern = cls.HANA_PLATFORM.format(platform=hana_platform)
+                if re.match(hana_pattern, file_ptr.read()):
+                    hdblcm_path = os.path.join(
+                        software_path, 'DATA_UNITS',
+                        'HDB_LCM_{}'.format(hana_platform), cls.INSTALL_EXEC)
+                    hdbserver_path = os.path.join(
+                        software_path, 'DATA_UNITS',
+                        'HDB_SERVER_{}'.format(hana_platform), cls.INSTALL_EXEC)
+                    if os.path.exists(hdblcm_path):
+                        return hdblcm_path
+                    elif os.path.exists(hdbserver_path):
+                        return hdbserver_path
+
+        # HANA server SAR patch
+        hana_server_path = os.path.join(software_path, 'SAP_HANA_DATABASE', cls.INSTALL_EXEC)
+        if os.path.exists(hana_server_path):
+            return hana_server_path
+
+        raise HanaSoftwareNotFoundError('HANA installer not found in {}'.format(software_path))
 
     def _run_hana_command(self, cmd, exception=True):
         """
@@ -209,8 +253,7 @@ class HanaInstance(object):
             remote_host (str, opt): Remote host where the command will be executed
 
         """
-        platform_folder = cls.get_platform()
-        executable = cls.INSTALL_EXEC.format(software_path=software_path, platform=platform_folder)
+        executable = cls.find_hana_hdblcm(software_path)
         cmd = '{executable} --action=install '\
             '--dump_configfile_template={conf_file}'.format(
                 executable=executable, conf_file=conf_file)
@@ -238,12 +281,12 @@ class HanaInstance(object):
         # TODO: do some integrity check stuff
 
         if not os.path.isfile(conf_file):
-            raise FileDoesNotExistError('The configuration file \'{}\' does not exist'.format(conf_file))
+            raise FileDoesNotExistError(
+                'The configuration file \'{}\' does not exist'.format(conf_file))
         if hdb_pwd_file is not None and not os.path.isfile(hdb_pwd_file):
-            raise FileDoesNotExistError('The XML password file \'{}\' does not exist'.format(hdb_pwd_file))
-
-        platform_folder = cls.get_platform()
-        executable = cls.INSTALL_EXEC.format(software_path=software_path, platform=platform_folder)
+            raise FileDoesNotExistError(
+                'The XML password file \'{}\' does not exist'.format(hdb_pwd_file))
+        executable = cls.find_hana_hdblcm(software_path)
         if hdb_pwd_file:
             cmd = 'cat {hdb_pwd_file} | {executable} -b '\
                 '--read_password_from_stdin=xml --configfile={conf_file}'.format(

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -35,7 +35,7 @@ class HanaError(Exception):
     Error during HANA command execution
     """
 
-class FileDoesNotExistError(Exception):
+class FileDoesNotExistError(HanaError):
     """
     Error when the specified files does not exist
     """

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -112,16 +112,19 @@ class TestHana(unittest.TestCase):
         self.assertTrue('not supported system: {}'.format('Mac') in str(err.exception))
         mock_machine.assert_called_once_with()
 
+    @mock.patch('logging.Logger.info')
     @mock.patch('os.path.exists')
-    def test_find_hana_hdblcm(self, mock_exists):
+    def test_find_hana_hdblcm(self, mock_exists, mock_info):
         mock_exists.return_value = True
         hdblcm = hana.HanaInstance.find_hana_hdblcm('software_path')
         assert hdblcm == 'software_path/hdblcm'
         mock_exists.assert_called_once_with('software_path/hdblcm')
+        mock_info.assert_called_once_with('HANA installer found: %s', 'software_path/hdblcm')
 
+    @mock.patch('logging.Logger.info')
     @mock.patch('shaptools.hana.HanaInstance.get_platform')
     @mock.patch('os.path.exists')
-    def test_find_hana_hdblcm_units_lcm(self, mock_exists, mock_get_platform):
+    def test_find_hana_hdblcm_units_lcm(self, mock_exists, mock_get_platform, mock_info):
         mock_exists.side_effect = [False, True, True]
         mock_get_platform.return_value = 'LINUX_X86_64'
 
@@ -136,10 +139,13 @@ class TestHana(unittest.TestCase):
             mock.call('software_path/LABEL.ASC'),
             mock.call('software_path/DATA_UNITS/HDB_LCM_LINUX_X86_64/hdblcm')
         ])
+        mock_info.assert_called_once_with(
+            'HANA installer found: %s', 'software_path/DATA_UNITS/HDB_LCM_LINUX_X86_64/hdblcm')
 
+    @mock.patch('logging.Logger.info')
     @mock.patch('shaptools.hana.HanaInstance.get_platform')
     @mock.patch('os.path.exists')
-    def test_find_hana_hdblcm_units_server(self, mock_exists, mock_get_platform):
+    def test_find_hana_hdblcm_units_server(self, mock_exists, mock_get_platform, mock_info):
         mock_exists.side_effect = [False, True, False, True]
         mock_get_platform.return_value = 'LINUX_X86_64'
 
@@ -155,9 +161,12 @@ class TestHana(unittest.TestCase):
             mock.call('software_path/DATA_UNITS/HDB_LCM_LINUX_X86_64/hdblcm'),
             mock.call('software_path/DATA_UNITS/HDB_SERVER_LINUX_X86_64/hdblcm')
         ])
+        mock_info.assert_called_once_with(
+            'HANA installer found: %s', 'software_path/DATA_UNITS/HDB_SERVER_LINUX_X86_64/hdblcm')
 
+    @mock.patch('logging.Logger.info')
     @mock.patch('os.path.exists')
-    def test_find_hana_hdblcm_extracted(self, mock_exists):
+    def test_find_hana_hdblcm_extracted(self, mock_exists, mock_info):
         mock_exists.side_effect = [False, False, True]
 
         hdblcm = hana.HanaInstance.find_hana_hdblcm('software_path')
@@ -168,6 +177,8 @@ class TestHana(unittest.TestCase):
             mock.call('software_path/LABEL.ASC'),
             mock.call('software_path/SAP_HANA_DATABASE/hdblcm')
         ])
+        mock_info.assert_called_once_with(
+            'HANA installer found: %s', 'software_path/SAP_HANA_DATABASE/hdblcm')
 
     @mock.patch('os.path.exists')
     def test_find_hana_hdblcm_error(self, mock_exists):


### PR DESCRIPTION
Improved hana installation software detection. Until now, we were just able to find the software in `DATA_UNITS/HDB_LCM?*`. With this change the software will be found in:
1. Directly in the provided folder
2. In` DATA_UNITS/HDB_LCM_*` (only if the folder is a HANA platform software)
3. In` DATA_UNITS/HDB_SERVER_*` (only if the folder is a HANA platform software)
4. In `SAP_HANA_DATABASE` (name used in the HANA SAR patches)