### PR TITLE
Hotfix/start stop with sapcontrol

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep  3 06:44:31 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Fix how HANA database is started and stopped to work in multi
+  host environment. sapcontrol commands are used instead of HDB
+  now 
+
+-------------------------------------------------------------------
 Tue Aug 25 06:53:29 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Create version 0.3.9

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -342,16 +342,26 @@ class HanaInstance(object):
 
     def start(self):
         """
-        Start hana instance
+        Start hana instance.
+
+        Info: 'HDB start' is not used, as this command only operates in the local machine and
+        it does not start machines in other host
         """
-        cmd = 'HDB start'
+        cmd = 'sapcontrol -nr {} -function StartSystem HDB'.format(self.inst)
+        self._run_hana_command(cmd)
+        cmd = 'sapcontrol -nr {} -function WaitforStarted 2700 2'.format(self.inst)
         self._run_hana_command(cmd)
 
     def stop(self):
         """
-        Stop hana instance
+        Stop hana instance.
+
+        Info: 'HDB stop' is not used, as this command only operates in the local machine and
+        it does not stop machines in other host
         """
-        cmd = 'HDB stop'
+        cmd = 'sapcontrol -nr {} -function StopSystem HDB'.format(self.inst)
+        self._run_hana_command(cmd)
+        cmd = 'sapcontrol -nr {} -function WaitforStopped 2700 2'.format(self.inst)
         self._run_hana_command(cmd)
 
     def get_sr_state(self):

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -345,11 +345,14 @@ class HanaInstance(object):
         Start hana instance.
 
         Info: 'HDB start' is not used, as this command only operates in the local machine and
-        it does not start machines in other host
+        it does not start machines in other host. The used timeout and delay values are the same
+        used by 'HDB start'
         """
+        timeout = 2700
+        delay = 2
         cmd = 'sapcontrol -nr {} -function StartSystem HDB'.format(self.inst)
         self._run_hana_command(cmd)
-        cmd = 'sapcontrol -nr {} -function WaitforStarted 2700 2'.format(self.inst)
+        cmd = 'sapcontrol -nr {} -function WaitforStarted {} {}'.format(self.inst, timeout, delay)
         self._run_hana_command(cmd)
 
     def stop(self):
@@ -357,11 +360,14 @@ class HanaInstance(object):
         Stop hana instance.
 
         Info: 'HDB stop' is not used, as this command only operates in the local machine and
-        it does not stop machines in other host
+        it does not stop machines in other host. The used timeout and delay values are the same
+        used by 'HDB start'
         """
+        timeout = 2700
+        delay = 2
         cmd = 'sapcontrol -nr {} -function StopSystem HDB'.format(self.inst)
         self._run_hana_command(cmd)
-        cmd = 'sapcontrol -nr {} -function WaitforStopped 2700 2'.format(self.inst)
+        cmd = 'sapcontrol -nr {} -function WaitforStopped {} {}'.format(self.inst, timeout, delay)
         self._run_hana_command(cmd)
 
     def get_sr_state(self):

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -481,13 +481,19 @@ class TestHana(unittest.TestCase):
         mock_command = mock.Mock()
         self._hana._run_hana_command = mock_command
         self._hana.start()
-        mock_command.assert_called_once_with('HDB start')
+        mock_command.assert_has_calls([
+            mock.call('sapcontrol -nr {} -function StartSystem HDB'.format(self._hana.inst)),
+            mock.call('sapcontrol -nr {} -function WaitforStarted 2700 2'.format(self._hana.inst))
+        ])
 
     def test_stop(self):
         mock_command = mock.Mock()
         self._hana._run_hana_command = mock_command
         self._hana.stop()
-        mock_command.assert_called_once_with('HDB stop')
+        mock_command.assert_has_calls([
+            mock.call('sapcontrol -nr {} -function StopSystem HDB'.format(self._hana.inst)),
+            mock.call('sapcontrol -nr {} -function WaitforStopped 2700 2'.format(self._hana.inst))
+        ])
 
     @mock.patch('shaptools.shell.find_pattern', mock.Mock(return_value=object()))
     def test_get_sr_state_primary(self):


### PR DESCRIPTION
Replace `HDB` command usage by `sapcontrol`.

`HDB` command only affects the local machine, and if a multi host environment is used, this causes issues, as it doesn't operated all the machines. Using `sapcontrol` `StartSystem/StopSystem` and the corresponding wait methods fixes this issues, as these actions affect all the hosts in the same site.

I have set the `2700` and `2` values as these are the values used by `HDB`. I don't think adding this values as parameters will help much (adding more complexity). I guess SAP used these values for some good reason.