### PR TITLE
Feature/implement ensa differences

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Sep 24 12:16:46 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Add new functionalities to know the currently installed ENSA
+  version for Netweaver (only for ASCS and ERS instances) 
+
+-------------------------------------------------------------------
 Thu Sep  3 06:44:31 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Create version 0.3.10

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -116,16 +116,20 @@ class NetweaverInstance(object):
         Check if ASCS instance is installed
         """
         msg_server = shell.find_pattern(r'msg_server, MessageServer,.*', processes.output)
-        enserver = shell.find_pattern(r'enserver, EnqueueServer,.*', processes.output)
-        return bool(msg_server and enserver)
+        enserver_ensa1 = shell.find_pattern(r'enserver, EnqueueServer,.*', processes.output)
+        enq_server_ensa2 = shell.find_pattern(r'enq_server, Enqueue Server 2,.*', processes.output)
+        return bool(msg_server and (enserver_ensa1 or enq_server_ensa2))
 
     @staticmethod
     def _is_ers_installed(processes):
         """
         Check if ERS instance is installed
         """
-        enrepserver = shell.find_pattern(r'enrepserver, EnqueueReplicator,.*', processes.output)
-        return bool(enrepserver)
+        enrepserver_ensa1 = shell.find_pattern(
+            r'enrepserver, EnqueueReplicator,.*', processes.output)
+        enq_replicator_ensa2 = shell.find_pattern(
+            r'enq_replicator, Enqueue Replicator 2,.*', processes.output)
+        return bool(enrepserver_ensa1 or enq_replicator_ensa2)
 
     @staticmethod
     def _is_app_server_installed(processes):
@@ -164,6 +168,49 @@ class NetweaverInstance(object):
         else:
             raise ValueError('provided sap instance type is not valid: {}'.format(sap_instance))
         return state
+
+    @staticmethod
+    def _get_ascs_ensa_version(processes):
+        """
+        Get ASCS ENSA version
+        """
+        if shell.find_pattern(r'enserver, EnqueueServer,.*', processes.output):
+            return 1
+        elif shell.find_pattern(r'enq_server, Enqueue Server 2,.*', processes.output):
+            return 2
+        raise ValueError('ASCS not installed or found')
+
+    @staticmethod
+    def _get_ers_ensa_version(processes):
+        """
+        Get ERS ENSA version
+        """
+        if shell.find_pattern(r'enrepserver, EnqueueReplicator,.*', processes.output):
+            return 1
+        elif shell.find_pattern(r'enq_replicator, Enqueue Replicator 2,.*', processes.output):
+            return 2
+        raise ValueError('ERS not installed or found')
+
+    def get_ensa_version(self, sap_instance):
+        """
+        Get currently installed ENSA version
+
+        Args:
+            sap_instance (str): SAP instance type. Available options: ascs, ers
+
+        Returns:
+            int: Returns the ENSA version number
+
+        Raises:
+            ValueError: ENSA system is not installed or found properly
+        """
+
+        processes = self.get_process_list(False)
+        if sap_instance == 'ascs':
+            return self._get_ascs_ensa_version(processes)
+        elif sap_instance == 'ers':
+            return self._get_ers_ensa_version(processes)
+        raise ValueError('provided sap instance type is not valid: {}'.format(sap_instance))
 
     @staticmethod
     def _remove_old_files(cwd, root_user, password, remote_host):

--- a/shaptools/netweaver.py
+++ b/shaptools/netweaver.py
@@ -205,7 +205,7 @@ class NetweaverInstance(object):
             ValueError: ENSA system is not installed or found properly
         """
 
-        processes = self.get_process_list(False)
+        processes = self.get_process_list(exception=True)
         if sap_instance == 'ascs':
             return self._get_ascs_ensa_version(processes)
         elif sap_instance == 'ers':

--- a/tests/netweaver_test.py
+++ b/tests/netweaver_test.py
@@ -397,7 +397,7 @@ class TestNetweaver(unittest.TestCase):
         self._netweaver._get_ascs_ensa_version = mock.Mock(return_value=1)
         version = self._netweaver.get_ensa_version('ascs')
         self.assertTrue(version, 1)
-        self._netweaver.get_process_list.assert_called_once_with(False)
+        self._netweaver.get_process_list.assert_called_once_with(exception=True)
         self._netweaver._get_ascs_ensa_version.assert_called_once_with('output')
 
     def test_get_ensa_version_ers(self):
@@ -405,7 +405,7 @@ class TestNetweaver(unittest.TestCase):
         self._netweaver._get_ers_ensa_version = mock.Mock(return_value=1)
         version = self._netweaver.get_ensa_version('ers')
         self.assertTrue(version, 1)
-        self._netweaver.get_process_list.assert_called_once_with(False)
+        self._netweaver.get_process_list.assert_called_once_with(exception=True)
         self._netweaver._get_ers_ensa_version.assert_called_once_with('output')
 
     def test_get_ensa_version_error(self):
@@ -413,7 +413,7 @@ class TestNetweaver(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             self._netweaver.get_ensa_version('other')
         self.assertTrue('provided sap instance type is not valid: other' in str(err.exception))
-        self._netweaver.get_process_list.assert_called_once_with(False)
+        self._netweaver.get_process_list.assert_called_once_with(exception=True)
 
     @mock.patch('shaptools.shell.execute_cmd')
     def test_remove_old_files(self, mock_execute_cmd):

--- a/tests/netweaver_test.py
+++ b/tests/netweaver_test.py
@@ -156,7 +156,7 @@ class TestNetweaver(unittest.TestCase):
     def test_is_ascs_installed(self, mock_find_pattern):
 
         mock_process = mock.Mock(output='output')
-        mock_find_pattern.side_effect = ['found', 'found']
+        mock_find_pattern.side_effect = ['found', 'found', '']
 
         self.assertTrue(self._netweaver._is_ascs_installed(mock_process))
 
@@ -166,33 +166,60 @@ class TestNetweaver(unittest.TestCase):
         ])
 
         mock_find_pattern.reset_mock()
-        mock_find_pattern.side_effect = ['found', '']
+
+        mock_find_pattern.side_effect = ['found', '', 'found']
+
+        self.assertTrue(self._netweaver._is_ascs_installed(mock_process))
+
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'msg_server, MessageServer,.*', 'output'),
+            mock.call(r'enserver, EnqueueServer,.*', 'output'),
+            mock.call(r'enq_server, Enqueue Server 2,.*', 'output')
+        ])
+
+        mock_find_pattern.reset_mock()
+        mock_find_pattern.side_effect = ['found', '', '']
 
         self.assertFalse(self._netweaver._is_ascs_installed(mock_process))
 
         mock_find_pattern.assert_has_calls([
             mock.call(r'msg_server, MessageServer,.*', 'output'),
-            mock.call(r'enserver, EnqueueServer,.*', 'output')
+            mock.call(r'enserver, EnqueueServer,.*', 'output'),
+            mock.call(r'enq_server, Enqueue Server 2,.*', 'output')
         ])
 
     @mock.patch('shaptools.shell.find_pattern')
     def test_is_ers_installed(self, mock_find_pattern):
 
         mock_process = mock.Mock(output='output')
-        mock_find_pattern.side_effect = ['found']
+        mock_find_pattern.side_effect = ['found', '']
 
         self.assertTrue(self._netweaver._is_ers_installed(mock_process))
 
-        mock_find_pattern.assert_called_once_with(
-            r'enrepserver, EnqueueReplicator,.*', 'output')
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'enrepserver, EnqueueReplicator,.*', 'output'),
+            mock.call(r'enq_replicator, Enqueue Replicator 2,.*', 'output'),
+        ])
 
         mock_find_pattern.reset_mock()
-        mock_find_pattern.side_effect = ['']
+        mock_find_pattern.side_effect = ['', 'found']
+
+        self.assertTrue(self._netweaver._is_ers_installed(mock_process))
+
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'enrepserver, EnqueueReplicator,.*', 'output'),
+            mock.call(r'enq_replicator, Enqueue Replicator 2,.*', 'output'),
+        ])
+
+        mock_find_pattern.reset_mock()
+        mock_find_pattern.side_effect = ['', '']
 
         self.assertFalse(self._netweaver._is_ers_installed(mock_process))
 
-        mock_find_pattern.assert_called_once_with(
-            r'enrepserver, EnqueueReplicator,.*', 'output')
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'enrepserver, EnqueueReplicator,.*', 'output'),
+            mock.call(r'enq_replicator, Enqueue Replicator 2,.*', 'output'),
+        ])
 
     @mock.patch('shaptools.shell.find_pattern')
     def test_is_app_server_installed(self, mock_find_pattern):

--- a/tests/netweaver_test.py
+++ b/tests/netweaver_test.py
@@ -330,6 +330,91 @@ class TestNetweaver(unittest.TestCase):
         self._netweaver.get_process_list.assert_called_once_with(False)
         self._netweaver._is_app_server_installed.assert_called_once_with(processes_mock)
 
+    @mock.patch('shaptools.shell.find_pattern')
+    def test_get_ascs_ensa_version_ensa1(self, mock_find_pattern):
+        processes = mock.Mock(output='output')
+        mock_find_pattern.side_effect = [True, False]
+        version = self._netweaver._get_ascs_ensa_version(processes)
+        self.assertTrue(version, 1)
+        mock_find_pattern.assert_called_once_with(r'enserver, EnqueueServer,.*', 'output')
+
+    @mock.patch('shaptools.shell.find_pattern')
+    def test_get_ascs_ensa_version_ensa2(self, mock_find_pattern):
+        processes = mock.Mock(output='output')
+        mock_find_pattern.side_effect = [False, True]
+        version = self._netweaver._get_ascs_ensa_version(processes)
+        self.assertTrue(version, 2)
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'enserver, EnqueueServer,.*', 'output'),
+            mock.call(r'enq_server, Enqueue Server 2,.*', 'output')
+        ])
+
+    @mock.patch('shaptools.shell.find_pattern')
+    def test_get_ascs_ensa_version_error(self, mock_find_pattern):
+        processes = mock.Mock(output='output')
+        mock_find_pattern.side_effect = [False, False]
+        with self.assertRaises(ValueError) as err:
+            self._netweaver._get_ascs_ensa_version(processes)
+        self.assertTrue('ASCS not installed or found' in str(err.exception))
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'enserver, EnqueueServer,.*', 'output'),
+            mock.call(r'enq_server, Enqueue Server 2,.*', 'output')
+        ])
+
+    @mock.patch('shaptools.shell.find_pattern')
+    def test_get_ers_ensa_version_ensa1(self, mock_find_pattern):
+        processes = mock.Mock(output='output')
+        mock_find_pattern.side_effect = [True, False]
+        version = self._netweaver._get_ers_ensa_version(processes)
+        self.assertTrue(version, 1)
+        mock_find_pattern.assert_called_once_with(r'enrepserver, EnqueueReplicator,.*', 'output')
+
+    @mock.patch('shaptools.shell.find_pattern')
+    def test_get_ers_ensa_version_ensa2(self, mock_find_pattern):
+        processes = mock.Mock(output='output')
+        mock_find_pattern.side_effect = [False, True]
+        version = self._netweaver._get_ers_ensa_version(processes)
+        self.assertTrue(version, 2)
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'enrepserver, EnqueueReplicator,.*', 'output'),
+            mock.call(r'enq_replicator, Enqueue Replicator 2,.*', 'output')
+        ])
+
+    @mock.patch('shaptools.shell.find_pattern')
+    def test_get_ers_ensa_version_error(self, mock_find_pattern):
+        processes = mock.Mock(output='output')
+        mock_find_pattern.side_effect = [False, False]
+        with self.assertRaises(ValueError) as err:
+            self._netweaver._get_ers_ensa_version(processes)
+        self.assertTrue('ERS not installed or found' in str(err.exception))
+        mock_find_pattern.assert_has_calls([
+            mock.call(r'enrepserver, EnqueueReplicator,.*', 'output'),
+            mock.call(r'enq_replicator, Enqueue Replicator 2,.*', 'output')
+        ])
+
+    def test_get_ensa_version_ascs(self):
+        self._netweaver.get_process_list = mock.Mock(return_value='output')
+        self._netweaver._get_ascs_ensa_version = mock.Mock(return_value=1)
+        version = self._netweaver.get_ensa_version('ascs')
+        self.assertTrue(version, 1)
+        self._netweaver.get_process_list.assert_called_once_with(False)
+        self._netweaver._get_ascs_ensa_version.assert_called_once_with('output')
+
+    def test_get_ensa_version_ers(self):
+        self._netweaver.get_process_list = mock.Mock(return_value='output')
+        self._netweaver._get_ers_ensa_version = mock.Mock(return_value=1)
+        version = self._netweaver.get_ensa_version('ers')
+        self.assertTrue(version, 1)
+        self._netweaver.get_process_list.assert_called_once_with(False)
+        self._netweaver._get_ers_ensa_version.assert_called_once_with('output')
+
+    def test_get_ensa_version_error(self):
+        self._netweaver.get_process_list = mock.Mock(return_value='output')
+        with self.assertRaises(ValueError) as err:
+            self._netweaver.get_ensa_version('other')
+        self.assertTrue('provided sap instance type is not valid: other' in str(err.exception))
+        self._netweaver.get_process_list.assert_called_once_with(False)
+
     @mock.patch('shaptools.shell.execute_cmd')
     def test_remove_old_files(self, mock_execute_cmd):
 


### PR DESCRIPTION
Add new code to know which is the currently installed ENSA version for Netweaver.
Basically, it implements some changes to correctly check the `sapcontrol` output to know if ENSA1 or ENSA2 is the installed version.

Unfortunately, `sapcontrol` output is not documented anywhere, so I cannot link the used string to anywhere.

The chanages are based in and in a trial/error:
https://github.com/ClusterLabs/resource-agents/blob/master/heartbeat/SAPInstance#L173

More information in:
https://www.suse.com/c/suse-ha-sap-certified/
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse#2d6008b0-685d-426c-b59e-6cd281fd45d7
https://launchpad.support.sap.com/#/notes/1410736

FYI @petersatsuse
