### PR TITLE
Fix spec file to package shapcli correctly in factory

### DIFF
--- a/python-shaptools.spec
+++ b/python-shaptools.spec
@@ -36,6 +36,8 @@ BuildRequires:  %{python_module pytest}
 BuildRequires:  %{python_module setuptools}
 BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
+Requires(post): update-alternatives
+Requires(postun): update-alternatives
 BuildArch:      noarch
 %python_subpackages
 
@@ -53,6 +55,13 @@ API to expose SAP HANA functionalities
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 # do not install tests
 %python_expand rm -r %{buildroot}%{$python_sitelib}/tests
+%python_clone -a %{buildroot}%{_bindir}/shapcli
+
+%post
+%python_install_alternative shapcli
+
+%postun
+%python_uninstall_alternative shapcli
 
 %if %{with test}
 %check
@@ -67,6 +76,6 @@ API to expose SAP HANA functionalities
 %license LICENSE
 %endif
 %{python_sitelib}/*
-%python3_only %{_bindir}/shapcli
+%python_alternative %{_bindir}/shapcli
 
 %changelog


### PR DESCRIPTION
Fix the spec file to build properly in openSUSE: Factory.

The issue was about how the `shapcli` executable is packaged. The latest Factory version deprecates the `python3-only` macro, so it must be updated by the `python_alternative` option.

Here more info:
https://en.opensuse.org/openSUSE:Packaging_Python#Executables

I have not upgraded the package version as it doesn't bring any real change, and the unique difference belongs to the spec file. OBS will just create the same version with a newer git commit number.

Here the build with green light: https://build.opensuse.org/package/show/home:xarbulu:sap-deployment/python-shaptools