### PR TITLE
Fix how sidadm user is transformed to lowercase

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 12 14:59:00 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Fix the HANA sidadm user creation to transform to lowercase 
+  properly 
+
+-------------------------------------------------------------------
 Tue Feb  9 13:26:18 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Fix spec file to build properly the shapcli executable 

--- a/shaptools/hana.py
+++ b/shaptools/hana.py
@@ -84,8 +84,6 @@ class HanaInstance(object):
         'x86_64', 'ppc64le'
     ]
     SUPPORTED_SYSTEMS = ['Linux']
-    # SID is usualy written uppercased, but the OS user is always created lower case.
-    HANAUSER = '{sid}adm'.lower()
     SYNCMODES = ['sync', 'syncmem', 'async']
     SUCCESSFULLY_REGISTERED = 0 # Node correctly registered as secondary node
     SSFS_DIFFERENT_ERROR = 149 # ssfs files are different in the two nodes error return code
@@ -102,6 +100,13 @@ class HanaInstance(object):
         self.inst = inst
         self._password = password
         self.remote_host = kwargs.get('remote_host', None)
+
+    @staticmethod
+    def sidadm_user(sid):
+        """
+        Get sidadm user. `{sid}adm` in lower case
+        """
+        return '{sid}adm'.format(sid=sid).lower()
 
     @classmethod
     def get_platform(cls):
@@ -178,7 +183,7 @@ class HanaInstance(object):
                 stdout and stderr
         """
         #TODO: Add absolute paths to hana commands using sid and inst number
-        user = self.HANAUSER.format(sid=self.sid)
+        user = self.sidadm_user(self.sid)
         result = shell.execute_cmd(cmd, user, self._password, self.remote_host)
 
         if exception and result.returncode != 0:
@@ -193,7 +198,7 @@ class HanaInstance(object):
         Returns:
             bool: True if installed, False otherwise
         """
-        user = self.HANAUSER.format(sid=self.sid)
+        user = self.sidadm_user(self.sid)
         try:
             result = shell.execute_cmd('HDB info', user, self._password, self.remote_host)
             return not result.returncode
@@ -443,7 +448,7 @@ class HanaInstance(object):
         Args:
             primary_pass: Password of the primary node
         """
-        user = self.HANAUSER.format(sid=self.sid)
+        user = self.sidadm_user(self.sid)
         sid_upper = self.sid.upper()
         cmd = \
             "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "\

--- a/shaptools/shapcli.py
+++ b/shaptools/shapcli.py
@@ -230,7 +230,7 @@ def uninstall(hana_instance, logger):
         hana_instance.sid, hana_instance.inst)
     response = input()
     if response == 'y':
-        user = hana.HanaInstance.HANAUSER.format(sid=hana_instance.sid)
+        user = hana.HanaInstance.sidadm_user(sid=hana_instance.sid)
         hana_instance.uninstall(user, hana_instance._password)
     else:
         logger.info('Command execution canceled')

--- a/tests/hana_test.py
+++ b/tests/hana_test.py
@@ -208,6 +208,19 @@ class TestHana(unittest.TestCase):
         self.assertEqual(proc_mock, result)
 
     @mock.patch('shaptools.shell.execute_cmd')
+    def test_run_hana_command_uppercase(self, mock_execute):
+        proc_mock = mock.Mock()
+        proc_mock.returncode = 0
+
+        mock_execute.return_value = proc_mock
+
+        self._hana = hana.HanaInstance('PRD', 1, 'pass')
+        result = self._hana._run_hana_command('test command')
+
+        mock_execute.assert_called_once_with('test command', 'prdadm', 'pass', None)
+        self.assertEqual(proc_mock, result)
+
+    @mock.patch('shaptools.shell.execute_cmd')
     def test_run_hana_command_error(self, mock_execute):
         proc_mock = mock.Mock()
         proc_mock.returncode = 1


### PR DESCRIPTION
The sidadm transformation is implemented incorrectly.

```
>>> HANAUSER = '{sid}adm'.lower()
>>> HANAUSER.format(sid='PRD')
'PRDadm'
>>> 

```
This should return `prdadm`.
I have reimplemented the usage to transform correctly to lowercase.
This was affecting the `saphanabootstrap-formula` usage in the `ha_cluster.sls` state if the configured sid is in upper case.

We have not found this on the `ha-sap-terraform-deployments` project because the system identifier is always lowercased before adding to the hana.sls pillar file

FYI: @petersatsuse