### PR TITLE
ci: remove unused PARENT_TAG from _service to fix delivery/obs-packaging via github actions

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">python-shaptools</param>
-    <param name="versionformat">@PARENT_TAG@+git.%ct.%h</param>
+    <param name="versionformat">0.3.13+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 


### PR DESCRIPTION
Adapt `_service` handling from https://github.com/SUSE/salt-shaptools.
This seems to never have worked before (after move from travis to github-ci).