### PR TITLE
Remove mock BuildRequires

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Jan  5 23:44:22 UTC 2023 - Steve Kowalik <steven.kowalik@suse.com>
+
+- Only BuildRequire python-mock under Python 2.
+
+-------------------------------------------------------------------
 Fri Mar 25 15:45:21 UTC 2021 - Eike Walldt <waldt@b1-systems.de>
 
 - Create version 0.3.13

--- a/python-shaptools.spec
+++ b/python-shaptools.spec
@@ -30,8 +30,10 @@ Group:          Development/Languages/Python
 Url:            https://github.com/SUSE/shaptools
 Source:         %{name}-%{version}.tar.gz
 %if %{with test}
-BuildRequires:  %{python_module mock}
 BuildRequires:  %{python_module pytest}
+%endif
+%ifpython2
+BuildRequires:  python-mock
 %endif
 BuildRequires:  %{python_module setuptools}
 BuildRequires:  fdupes


### PR DESCRIPTION
Since SLE-15-SP4 and Tumbleweed no longer ship Python 2, we are attempting to remove usage of mock which is no longer required with Python >= 3.4. Remove the BuildRequires, since the code does not require any changes.

Fixes #73