### PR TITLE
Correct macro usage around installing python-mock

### DIFF
--- a/python-shaptools.changes
+++ b/python-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Jan 13 02:13:36 UTC 2023 - Steve Kowalik <steven.kowalik@suse.com>
+
+- Correct macro usage, %ifpython2 is only suitable for Requires.
+
+-------------------------------------------------------------------
 Thu Jan  5 23:44:22 UTC 2023 - Steve Kowalik <steven.kowalik@suse.com>
 
 - Only BuildRequire python-mock under Python 2.

--- a/python-shaptools.spec
+++ b/python-shaptools.spec
@@ -20,6 +20,12 @@
 %bcond_without test
 %endif
 
+%if 0%{?sle_version} <= 150300 && !0%{?is_opensuse}
+%bcond_without python2
+%else
+%bcond_with python2
+%endif
+
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-shaptools
 Version:        0
@@ -32,7 +38,7 @@ Source:         %{name}-%{version}.tar.gz
 %if %{with test}
 BuildRequires:  %{python_module pytest}
 %endif
-%ifpython2
+%if %{with python2}
 BuildRequires:  python-mock
 %endif
 BuildRequires:  %{python_module setuptools}


### PR DESCRIPTION
The macro that was added to control whether or not python-mock is installed is not suitable for BuildRequires, because it is only checked during a build, and therefore should only be used for Requires. Switch to %bcond block using the correct version number.