### PR TITLE
Drop python2 and SLE12 version tests from CI

### DIFF
--- a/.github/workflows/shaptools-ci.yml
+++ b/.github/workflows/shaptools-ci.yml
@@ -151,7 +151,6 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - registry.suse.com/suse/sles12sp5:latest  # python 2.7
           - registry.suse.com/bci/bci-base:15.5      # python 3.6
     container:
       image: ${{ matrix.container }}
@@ -168,24 +167,13 @@ jobs:
       - name: Install dependencies
         run: |
           zypper -n in -y make python
-          if test -f /usr/bin/python3; then
-            # minimal salt, python packages and compilers
-            zypper -n in -y salt python3-pip python3-devel gcc
-            # use current salt version shipped with SLE 15
-            git clone --branch=openSUSE/release/3006.0 --depth=50 https://github.com/openSUSE/salt ../salt
-            # python 3.6 - official requirements from salt (works with python >3.6)
-            pip install -r ../salt/requirements/pytest.txt
-            pip install -r tests/requirements.3.6.yaml # pinned pytest-cov
-          else
-            zypper -n in -y SUSEConnect
-            SUSEConnect -p sle-module-adv-systems-management/12/x86_64
-            # minimal salt, python packages and compilers
-            zypper -n in -y salt python-pip python-devel gcc gcc-c++
-            # python 2.7 - latest available versions for old python release
-            pip install --ignore-installed -r tests/requirements.2.7.yaml
-            # use current salt version shipped with SLE 12
-            git clone --branch=openSUSE/release/3000.3 --depth=50 https://github.com/openSUSE/salt ../salt
-          fi
+          # minimal salt, python packages and compilers
+          zypper -n in -y salt python3-pip python3-devel gcc
+          # use current salt version shipped with SLE 15
+          git clone --branch=openSUSE/release/3006.0 --depth=50 https://github.com/openSUSE/salt ../salt
+          # python 3.6 - official requirements from salt (works with python >3.6)
+          pip install -r ../salt/requirements/pytest.txt
+          pip install -r tests/requirements.3.6.yaml # pinned pytest-cov
           rm ../salt/tests/conftest.py
       - name: execute test script
         run: make test-python


### PR DESCRIPTION
The CI for python2 and SLE12 fails, as the github runners use a node version that is not available in SLE12.
As we don't support this version anymore, I'm removing the tests and make the execution slimmer.

This was the error:
```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```